### PR TITLE
feat: support and validate profile slugs

### DIFF
--- a/core/src/main/java/com/dylibso/mcpx4j/core/HttpClient.java
+++ b/core/src/main/java/com/dylibso/mcpx4j/core/HttpClient.java
@@ -24,21 +24,32 @@ public class HttpClient {
 
     // GET /api/profiles/~/default/installations
     public Map<String, ServletInstall> installations(String profileId) {
-        var uri = URI.create(baseUrl + "/api/profiles/~/" + profileId + "/installations");
+        var uri = URI.create(baseUrl + "/api/profiles/" + profileId + "/installations");
         byte[] bytes = httpAdapter.request("GET", uri, Map.of("Cookie", "sessionId=" + apiKey), new byte[0]);
+        if (httpAdapter.statusCode() != 200) {
+            throw new HttpClientException("Failed to fetch installations: " + httpAdapter.statusCode());
+        }
         return jsonDecoder.servletInstalls(bytes);
     }
 
     // GET /c/{contentAddress}
     public byte[] fetch(ServletInstall servletInstall) {
         var uri = URI.create(baseUrl + "/api/c/" + servletInstall.servlet().meta().lastContentAddress());
-        return httpAdapter.request("GET", uri, Map.of("Cookie", "sessionId=" + apiKey), new byte[0]);
+        byte[] bytes = httpAdapter.request("GET", uri, Map.of("Cookie", "sessionId=" + apiKey), new byte[0]);
+        if (httpAdapter.statusCode() != 200) {
+            throw new HttpClientException("Failed to fetch installations: " + httpAdapter.statusCode());
+        }
+        return bytes;
     }
 
     // GET /api/servlets
     public byte[] search(String query) {
         var uri = URI.create(baseUrl + "/api/servlets");
-        return httpAdapter.request("GET", uri, Map.of("Cookie", "sessionId=" + apiKey), new byte[0]);
+        byte[] bytes = httpAdapter.request("GET", uri, Map.of("Cookie", "sessionId=" + apiKey), new byte[0]);
+        if (httpAdapter.statusCode() != 200) {
+            throw new HttpClientException("Failed to fetch installations: " + httpAdapter.statusCode());
+        }
+        return bytes;
     }
 
 }

--- a/core/src/main/java/com/dylibso/mcpx4j/core/HttpClientException.java
+++ b/core/src/main/java/com/dylibso/mcpx4j/core/HttpClientException.java
@@ -1,0 +1,7 @@
+package com.dylibso.mcpx4j.core;
+
+public class HttpClientException extends IllegalArgumentException {
+    public HttpClientException(String s) {
+        super(s);
+    }
+}

--- a/core/src/main/java/com/dylibso/mcpx4j/core/Mcpx.java
+++ b/core/src/main/java/com/dylibso/mcpx4j/core/Mcpx.java
@@ -4,6 +4,8 @@ import com.dylibso.mcpx4j.core.builtins.McpRunServlet;
 import org.extism.sdk.chicory.HttpClientAdapter;
 import org.extism.sdk.chicory.JdkHttpClientAdapter;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -68,29 +70,24 @@ public class Mcpx {
 
         /**
          * @param profile is a list of components for a slug. It may be empty (then it defaults to `~/default`),
-         *                it may contain one single value `"default"`.
-         *                Otherwise, it must contain two components, the first being a username
-         *                and the second being a profile name.
-         *                Neither the profile name nor the username may contain a slash.
-         *                It is also allowed to pass the values `"~", "default"`, yielding `~/default`.
+         *                it may contain one single value `hello` then it will resolve to `~/hello`.
+         *                Otherwise, it must contain two components: a username and a profile name.
+         *                The username may be `~` which is a shorthand for current user's profile.
          */
         static String profileIdToSlug(String... profile) {
             if (profile.length == 0) {
                 return "~/default";
             }
             if (profile.length == 1) {
-                if (profile[0].contains("/")) {
-                    throw new IllegalArgumentException("Invalid profile path: " + Arrays.toString(profile));
-                }
-                return "~/" + profile[0];
+                return "~/" + URLEncoder.encode(profile[0], StandardCharsets.UTF_8);
             }
             if (profile.length > 2) {
                 throw new IllegalArgumentException("Invalid profile path: " + Arrays.toString(profile));
             }
-            if (profile[0].contains("/") ||  profile[1].contains("/")) {
-                throw new IllegalArgumentException("Invalid profile path: " + Arrays.toString(profile));
-            }
-            return profile[0] + "/" + profile[1];
+            String ns = profile[0].equals("~")? "~" : URLEncoder.encode(profile[0], StandardCharsets.UTF_8);
+            String p = URLEncoder.encode(profile[1], StandardCharsets.UTF_8);
+
+            return ns + "/" + p;
         }
     }
 

--- a/core/src/main/java/com/dylibso/mcpx4j/core/Mcpx.java
+++ b/core/src/main/java/com/dylibso/mcpx4j/core/Mcpx.java
@@ -83,6 +83,15 @@ public class Mcpx {
         this.builtIns = List.of(new McpRunServlet(client, jsonDecoder));
     }
 
+    /**
+     * Refresh the list of installations for the given profile.
+     * @param profileId is a list of components for a slug. It may be empty (then it defaults to `~/default`),
+     *                  it may contain one single value `"default"`.
+     *                  Otherwise, it must contain two components, the first being a username
+     *                  and the second being a profile name.
+     *                  Neither the profile name nor the username may contain a slash.
+     *                  It is also allowed to pass the values `"~", "default"`, yielding `~/default`.
+     */
     public void refreshInstallations(String... profileId) {
         String slug = profileIdToSlug(profileId);
         Map<String, ServletInstall> installations = client.installations(slug);

--- a/core/src/main/java/com/dylibso/mcpx4j/core/Mcpx.java
+++ b/core/src/main/java/com/dylibso/mcpx4j/core/Mcpx.java
@@ -5,6 +5,7 @@ import org.extism.sdk.chicory.HttpClientAdapter;
 import org.extism.sdk.chicory.JdkHttpClientAdapter;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -82,9 +83,30 @@ public class Mcpx {
         this.builtIns = List.of(new McpRunServlet(client, jsonDecoder));
     }
 
-    public void refreshInstallations(String profileId) {
-        Map<String, ServletInstall> installations = client.installations(profileId);
+    public void refreshInstallations(String... profileId) {
+        String slug = profileIdToSlug(profileId);
+        Map<String, ServletInstall> installations = client.installations(slug);
         servletInstalls.putAll(installations);
+    }
+
+    String profileIdToSlug(String... profile) {
+        if (profile.length == 0) {
+            return "~/default";
+        }
+        if (profile.length == 1) {
+            if (profile[0].equals("default")) {
+                return "~/default";
+            } else {
+                throw new IllegalArgumentException("Invalid profile path: " + Arrays.toString(profile));
+            }
+        }
+        if (profile.length > 2) {
+            throw new IllegalArgumentException("Invalid profile path: " + Arrays.toString(profile));
+        }
+        if (profile[0].equals("~") && !profile[1].equals("default") || profile[0].contains("/") ||  profile[1].contains("/")) {
+            throw new IllegalArgumentException("Invalid profile path: " + Arrays.toString(profile));
+        }
+        return profile[0] + "/" + profile[1];
     }
 
     public McpxServletFactory get(String name) {

--- a/core/src/main/java/com/dylibso/mcpx4j/core/Mcpx.java
+++ b/core/src/main/java/com/dylibso/mcpx4j/core/Mcpx.java
@@ -79,16 +79,15 @@ public class Mcpx {
                 return "~/default";
             }
             if (profile.length == 1) {
-                if (profile[0].equals("default")) {
-                    return "~/default";
-                } else {
+                if (profile[0].contains("/")) {
                     throw new IllegalArgumentException("Invalid profile path: " + Arrays.toString(profile));
                 }
+                return "~/" + profile[0];
             }
             if (profile.length > 2) {
                 throw new IllegalArgumentException("Invalid profile path: " + Arrays.toString(profile));
             }
-            if (profile[0].equals("~") && !profile[1].equals("default") || profile[0].contains("/") ||  profile[1].contains("/")) {
+            if (profile[0].contains("/") ||  profile[1].contains("/")) {
                 throw new IllegalArgumentException("Invalid profile path: " + Arrays.toString(profile));
             }
             return profile[0] + "/" + profile[1];

--- a/core/src/main/java/com/dylibso/mcpx4j/core/McpxServletFactory.java
+++ b/core/src/main/java/com/dylibso/mcpx4j/core/McpxServletFactory.java
@@ -12,13 +12,13 @@ import java.util.Map;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-class McpxServletFactory {
+public class McpxServletFactory {
     private final ServletInstall install;
     private final Manifest manifest;
     private final McpxServletOptions config;
     private final JsonDecoder jsonDecoder;
 
-    public McpxServletFactory(ServletInstall install, Manifest manifest, McpxServletOptions config, JsonDecoder jsonDecoder) {
+    McpxServletFactory(ServletInstall install, Manifest manifest, McpxServletOptions config, JsonDecoder jsonDecoder) {
         this.install = install;
         this.manifest = manifest;
         this.config = config;

--- a/core/src/test/java/com/dylibso/mcpx4j/core/HttpClientIT.java
+++ b/core/src/test/java/com/dylibso/mcpx4j/core/HttpClientIT.java
@@ -28,10 +28,10 @@ class HttpClientIT {
     @ParameterizedTest
     @MethodSource("provideJsonDecoder")
     void installations(JsonDecoder jsonDecoder) throws IOException {
-        var profileId = "default";
+        var profileId = "~/default";
 
         var address = new InetSocketAddress(8080);
-        HttpServer server = MockServer.installations(address, profileId);
+        HttpServer server = MockServer.installations(address);
         String baseUrl = "http://" + address.getHostName() + ":" + address.getPort();
         try {
 
@@ -58,13 +58,10 @@ class HttpClientIT {
     @ParameterizedTest
     @MethodSource("provideJsonDecoder")
     void fetch(JsonDecoder jsonDecoder) throws IOException {
-        byte[] mockBody = this.getClass().getClassLoader().getResourceAsStream("installations.json").readAllBytes();
-        byte[] wasm = this.getClass().getClassLoader().getResourceAsStream("fetch.wasm").readAllBytes();
-        var profileId = "default";
-        var caddress = "abcdefg";
+        var profileId = "~/default";
 
         var address = new InetSocketAddress(8080);
-        HttpServer server = MockServer.fetch(address, profileId);
+        HttpServer server = MockServer.fetch(address);
         String baseUrl = "http://" + address.getHostName() + ":" + address.getPort();
 
         try {

--- a/core/src/test/java/com/dylibso/mcpx4j/core/McpxIT.java
+++ b/core/src/test/java/com/dylibso/mcpx4j/core/McpxIT.java
@@ -8,12 +8,10 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.util.List;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
@@ -22,28 +20,6 @@ class McpxIT {
         return Stream.of(
                 Arguments.of(new JacksonDecoder()),
                 Arguments.of(new JakartaJsonDecoder()));
-    }
-
-    @ParameterizedTest
-    @MethodSource("provideJsonDecoder")
-    void invalidSlug(JsonDecoder jsonDecoder) throws IOException {
-        var profileSlugs = List.of("foo/foo", "foo/bar");
-
-        var address = new InetSocketAddress(8080);
-        var server = MockServer.fetch(address);
-        String baseUrl = "http://" + address.getHostName() + ":" + address.getPort();
-        try {
-            server.start();
-            for (var profileSlug : profileSlugs) {
-                assertThrows(IllegalArgumentException.class,
-                        () -> Mcpx.forApiKey("my-key")
-                                .withBaseUrl(baseUrl)
-                                .withJsonDecoder(jsonDecoder)
-                                .withProfile(profileSlug).build(), profileSlug);
-            }
-        } finally {
-            server.stop(0);
-        }
     }
 
     @ParameterizedTest

--- a/core/src/test/java/com/dylibso/mcpx4j/core/McpxIT.java
+++ b/core/src/test/java/com/dylibso/mcpx4j/core/McpxIT.java
@@ -34,13 +34,12 @@ class McpxIT {
         String baseUrl = "http://" + address.getHostName() + ":" + address.getPort();
         try {
             server.start();
-            var mcpx = Mcpx.forApiKey("my-key")
-                    .withBaseUrl(baseUrl)
-                    .withJsonDecoder(jsonDecoder).build();
-
             for (var profileSlug : profileSlugs) {
                 assertThrows(IllegalArgumentException.class,
-                        () -> mcpx.refreshInstallations(profileSlug), profileSlug);
+                        () -> Mcpx.forApiKey("my-key")
+                                .withBaseUrl(baseUrl)
+                                .withJsonDecoder(jsonDecoder)
+                                .withProfile(profileSlug).build(), profileSlug);
             }
         } finally {
             server.stop(0);
@@ -60,8 +59,9 @@ class McpxIT {
 
             var mcpx = Mcpx.forApiKey("my-key")
                     .withBaseUrl(baseUrl)
+                    .withProfile(profileId)
                     .withJsonDecoder(jsonDecoder).build();
-            mcpx.refreshInstallations(profileId);
+            mcpx.refreshInstallations();
             McpxServletFactory servletFactory = mcpx.get("fetch");
 
             assertNotNull(servletFactory);

--- a/core/src/test/java/com/dylibso/mcpx4j/core/McpxIT.java
+++ b/core/src/test/java/com/dylibso/mcpx4j/core/McpxIT.java
@@ -27,7 +27,7 @@ class McpxIT {
     @ParameterizedTest
     @MethodSource("provideJsonDecoder")
     void invalidSlug(JsonDecoder jsonDecoder) throws IOException {
-        var profileSlugs = List.of("~/foo", "foo/bar");
+        var profileSlugs = List.of("foo/foo", "foo/bar");
 
         var address = new InetSocketAddress(8080);
         var server = MockServer.fetch(address);

--- a/core/src/test/java/com/dylibso/mcpx4j/core/McpxTest.java
+++ b/core/src/test/java/com/dylibso/mcpx4j/core/McpxTest.java
@@ -11,10 +11,6 @@ import static org.junit.jupiter.api.Assertions.*;
 class McpxTest {
     @Test
     void testSlug() {
-        var mcpx = Mcpx.forApiKey("my-key")
-                .withBaseUrl("http://localhost:8080")
-                .build();
-
         var cases = List.of(
                 Map.entry(s(), "~/default"),
                 Map.entry(s("default"), "~/default"),
@@ -25,7 +21,7 @@ class McpxTest {
         for (var c : cases) {
             var input = c.getKey();
             var expected = c.getValue();
-            var actual = mcpx.profileIdToSlug(input);
+            var actual = Mcpx.Builder.profileIdToSlug(input);
             assertEquals(expected, actual);
         }
 
@@ -40,7 +36,7 @@ class McpxTest {
         );
 
         for (var e : errors) {
-            assertThrows(IllegalArgumentException.class, () -> mcpx.profileIdToSlug(e), Arrays.toString(e));
+            assertThrows(IllegalArgumentException.class, () -> Mcpx.Builder.profileIdToSlug(e), Arrays.toString(e));
         }
     }
 

--- a/core/src/test/java/com/dylibso/mcpx4j/core/McpxTest.java
+++ b/core/src/test/java/com/dylibso/mcpx4j/core/McpxTest.java
@@ -6,7 +6,10 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static java.net.URLEncoder.encode;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class McpxTest {
     @Test
@@ -17,7 +20,11 @@ class McpxTest {
                 Map.entry(s("~", "default"), "~/default"),
                 Map.entry(s("abc"), "~/abc"),
                 Map.entry(s("~", "abc"), "~/abc"),
-                Map.entry(s("user", "foo"), "user/foo")
+                Map.entry(s("user", "foo"), "user/foo"),
+                Map.entry(s("x/y"), "~/" + encode("x/y", UTF_8)),
+                Map.entry(s("x/y/z"), "~/" + encode("x/y/z", UTF_8)),
+                Map.entry(s("x/y", "z"), encode("x/y", UTF_8) + "/z"),
+                Map.entry(s("x", "y/z"), "x/" + encode("y/z", UTF_8))
         );
 
         for (var c : cases) {
@@ -27,13 +34,7 @@ class McpxTest {
             assertEquals(expected, actual);
         }
 
-        var errors = List.of(
-                s("x", "y", "z"),
-                s("x/y"),
-                s("x/y/z"),
-                s("x/y", "z"),
-                s("x", "y/z")
-        );
+        var errors = new String[][]{s("x", "y", "z")};
 
         for (var e : errors) {
             assertThrows(IllegalArgumentException.class, () -> Mcpx.Builder.profileIdToSlug(e), Arrays.toString(e));

--- a/core/src/test/java/com/dylibso/mcpx4j/core/McpxTest.java
+++ b/core/src/test/java/com/dylibso/mcpx4j/core/McpxTest.java
@@ -15,6 +15,8 @@ class McpxTest {
                 Map.entry(s(), "~/default"),
                 Map.entry(s("default"), "~/default"),
                 Map.entry(s("~", "default"), "~/default"),
+                Map.entry(s("abc"), "~/abc"),
+                Map.entry(s("~", "abc"), "~/abc"),
                 Map.entry(s("user", "foo"), "user/foo")
         );
 
@@ -26,8 +28,6 @@ class McpxTest {
         }
 
         var errors = List.of(
-                s("~", "abc"),
-                s("x"),
                 s("x", "y", "z"),
                 s("x/y"),
                 s("x/y/z"),

--- a/core/src/test/java/com/dylibso/mcpx4j/core/McpxTest.java
+++ b/core/src/test/java/com/dylibso/mcpx4j/core/McpxTest.java
@@ -1,0 +1,50 @@
+package com.dylibso.mcpx4j.core;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class McpxTest {
+    @Test
+    void testSlug() {
+        var mcpx = Mcpx.forApiKey("my-key")
+                .withBaseUrl("http://localhost:8080")
+                .build();
+
+        var cases = List.of(
+                Map.entry(s(), "~/default"),
+                Map.entry(s("default"), "~/default"),
+                Map.entry(s("~", "default"), "~/default"),
+                Map.entry(s("user", "foo"), "user/foo")
+        );
+
+        for (var c : cases) {
+            var input = c.getKey();
+            var expected = c.getValue();
+            var actual = mcpx.profileIdToSlug(input);
+            assertEquals(expected, actual);
+        }
+
+        var errors = List.of(
+                s("~", "abc"),
+                s("x"),
+                s("x", "y", "z"),
+                s("x/y"),
+                s("x/y/z"),
+                s("x/y", "z"),
+                s("x", "y/z")
+        );
+
+        for (var e : errors) {
+            assertThrows(IllegalArgumentException.class, () -> mcpx.profileIdToSlug(e), Arrays.toString(e));
+        }
+    }
+
+    private String[] s(String... ss) {
+        return ss;
+    }
+}

--- a/core/src/test/java/com/dylibso/mcpx4j/core/MockServer.java
+++ b/core/src/test/java/com/dylibso/mcpx4j/core/MockServer.java
@@ -1,5 +1,6 @@
 package com.dylibso.mcpx4j.core;
 
+import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
 
 import java.io.IOException;
@@ -7,22 +8,27 @@ import java.io.OutputStream;
 import java.net.InetSocketAddress;
 
 public class MockServer {
-    static HttpServer installations(InetSocketAddress address, String profileId) throws IOException {
+    static HttpServer installations(InetSocketAddress address) throws IOException {
         byte[] mockBody = MockServer.class.getClassLoader().getResourceAsStream("installations.json").readAllBytes();
         HttpServer server = HttpServer.create(address, 0);
-        server.createContext("/api/profiles/~/" + profileId + "/installations", t -> {
+
+        HttpHandler httpHandler = t -> {
             t.sendResponseHeaders(200, mockBody.length);
             OutputStream os = t.getResponseBody();
             os.write(mockBody);
             os.close();
-        });
+        };
+
+        server.createContext("/api/profiles/~/default/installations", httpHandler);
+        server.createContext("/api/profiles/foo/bar/installations", httpHandler);
+
         return server;
     }
-    static HttpServer fetch(InetSocketAddress address, String profileId) throws IOException {
+    static HttpServer fetch(InetSocketAddress address) throws IOException {
         byte[] wasm = MockServer.class.getClassLoader().getResourceAsStream("fetch.wasm").readAllBytes();
         var caddress = "abcdefg";
 
-        HttpServer server = installations(address, profileId);
+        HttpServer server = installations(address);
         server.createContext("/api/c/" + caddress, t -> {
             byte[] bytes = wasm;
             t.sendResponseHeaders(200, bytes.length);

--- a/examples/langchain4j-ollama/src/main/java/com/dylibso/mcpx4j/examples/LangChain4jMcpx4jMain.java
+++ b/examples/langchain4j-ollama/src/main/java/com/dylibso/mcpx4j/examples/LangChain4jMcpx4jMain.java
@@ -37,12 +37,15 @@ public class LangChain4jMcpx4jMain {
         String profileId = config.getValue("mcpx.profile-id", String.class);
 
         // Instantiate a new Mcpx client with the configuration values.
-        var mcpx = Mcpx.forApiKey(apiKey).withBaseUrl(baseUrl).withProfile().build();
+        var mcpx = Mcpx.forApiKey(apiKey)
+                .withBaseUrl(baseUrl)
+                .withProfile(profileId)
+                .build();
         // Refresh the installed servlets definitions from mcp.run.
         // This will load the configuration once.
         // You can schedule this invocation periodically to refresh
         // such configuration.
-        mcpx.refreshInstallations(profileId);
+        mcpx.refreshInstallations();
         // Instantiate each servlet and expose it as a
         // `ToolSpecification`, `ToolExecutor` pair.
         var servlets = mcpx.servlets();

--- a/examples/langchain4j-ollama/src/main/java/com/dylibso/mcpx4j/examples/LangChain4jMcpx4jMain.java
+++ b/examples/langchain4j-ollama/src/main/java/com/dylibso/mcpx4j/examples/LangChain4jMcpx4jMain.java
@@ -37,7 +37,7 @@ public class LangChain4jMcpx4jMain {
         String profileId = config.getValue("mcpx.profile-id", String.class);
 
         // Instantiate a new Mcpx client with the configuration values.
-        var mcpx = Mcpx.forApiKey(apiKey).withBaseUrl(baseUrl).build();
+        var mcpx = Mcpx.forApiKey(apiKey).withBaseUrl(baseUrl).withProfile().build();
         // Refresh the installed servlets definitions from mcp.run.
         // This will load the configuration once.
         // You can schedule this invocation periodically to refresh

--- a/examples/langchain4j-openai/src/main/java/com/dylibso/mcpx4j/examples/LangChain4jOpenAIMcpx4jMain.java
+++ b/examples/langchain4j-openai/src/main/java/com/dylibso/mcpx4j/examples/LangChain4jOpenAIMcpx4jMain.java
@@ -38,12 +38,12 @@ public class LangChain4jOpenAIMcpx4jMain {
         String openAiApiKey = config.getValue("openai.api-key", String.class);
 
         // Instantiate a new Mcpx client with the configuration values.
-        var mcpx = Mcpx.forApiKey(apiKey).withBaseUrl(baseUrl).build();
+        var mcpx = Mcpx.forApiKey(apiKey).withBaseUrl(baseUrl).withProfile(profileId).build();
         // Refresh the installed servlets definitions from mcp.run.
         // This will load the configuration once.
         // You can schedule this invocation periodically to refresh
         // such configuration.
-        mcpx.refreshInstallations(profileId);
+        mcpx.refreshInstallations();
         // Instantiate each servlet and expose it as a
         // `ToolSpecification`, `ToolExecutor` pair.
         var servlets = mcpx.servlets();

--- a/examples/spring-ai-mcpx4j-ollama/src/main/java/com/dylibso/mcpx4j/examples/OllamaAiMcpx4jApplication.java
+++ b/examples/spring-ai-mcpx4j-ollama/src/main/java/com/dylibso/mcpx4j/examples/OllamaAiMcpx4jApplication.java
@@ -35,11 +35,11 @@ public class OllamaAiMcpx4jApplication {
                                      ConfigurableApplicationContext context) throws IOException {
 
         // Instantiate a new Mcpx client with the configuration values.
-        var mcpx = Mcpx.forApiKey(apiKey).withBaseUrl(baseUrl).build();
+        var mcpx = Mcpx.forApiKey(apiKey).withBaseUrl(baseUrl).withProfile(profileId).build();
         // Refresh the installed servlets definitions from mcp.run.
         // This will load the configuration once. You can schedule this invocation
         // periodically to refresh such configuration.
-        mcpx.refreshInstallations(profileId);
+        mcpx.refreshInstallations();
         // Instantiate each servlet and expose it as a `FunctionCallback`
         var functions = functionsFromMcpxServlets(mcpx.servlets());
 

--- a/examples/spring-ai-mcpx4j-openai/src/main/java/com/dylibso/mcpx4j/examples/OpenAiMcpx4jApplication.java
+++ b/examples/spring-ai-mcpx4j-openai/src/main/java/com/dylibso/mcpx4j/examples/OpenAiMcpx4jApplication.java
@@ -35,12 +35,12 @@ public class OpenAiMcpx4jApplication {
             ConfigurableApplicationContext context) {
 
         // Instantiate a new Mcpx client with the configuration values.
-        var mcpx = Mcpx.forApiKey(apiKey).withBaseUrl(baseUrl).build();
+        var mcpx = Mcpx.forApiKey(apiKey).withBaseUrl(baseUrl).withProfile(profileId).build();
         // Refresh the installed servlets definitions from mcp.run.
         // This will load the configuration once.
         // You can schedule this invocation periodically to refresh
         // such configuration.
-        mcpx.refreshInstallations(profileId);
+        mcpx.refreshInstallations();
         // Instantiate each servlet and expose it as a `FunctionCallback`
         var functions = functionsFromMcpxServlets(mcpx.servlets());
 


### PR DESCRIPTION
quoting @chrisdickinson

> The transformation rules are:
> 
> * `default` -> `~/default`
> * `~/default` -> `~/default`
> * `myuser/asdf` -> `myuser/asdf`
> 
> So an `activeProfile` of `banana` will produce the installation url `GET /profiles/~/banana/installations`; an `activeProfile` of `nilslice/refslice` will produce `GET /profiles/nilslice/refslice/installations`.

The change modifies the `Mcpx` builder, so that, optionally, users may provide a profile:

```java
        // Instantiate a new Mcpx client with the configuration values.
        var mcpx = Mcpx.forApiKey(apiKey)
            .withBaseUrl(baseUrl)
            .withProfile(profileId)
            .build();
        // Refresh the installed servlets definitions from mcp.run.
        // This will load the configuration once.
        // You can schedule this invocation periodically to refresh
        // such configuration.
        mcpx.refreshInstallations();
```

This makes the `mcpx` object effectively scoped to a single profile: this is intended to make cache management simpler.
