### PR TITLE
chore: depend on chicory-sdk on Maven Central

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,21 +5,12 @@ The MCP.RUN client library for Java!
 
 ## Installation
 
-MCPX4J is currently available on JitPack.
-
 ```xml
-<repositories>
-    <repository>
-        <id>jitpack.io</id>
-        <url>https://jitpack.io</url>
-    </repository>
-</repositories>
-
 <dependencies>
     <dependency>
-        <groupId>com.github.dylibso</groupId>
+       <groupId>com.dylibso.mcpx4j</groupId>
         <artifactId>mcpx4j</artifactId>
-        <version>main-SNAPSHOT</version>
+        <version>${mcpx4j.version}</version>
     </dependency>
 </dependencies>
 ```

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -13,7 +13,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.github.extism</groupId>
+            <groupId>org.extism.sdk</groupId>
             <artifactId>chicory-sdk</artifactId>
             <version>0.1.0</version>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -24,13 +24,6 @@
         <maven-failsafe-plugin.version>3.5.2</maven-failsafe-plugin.version>
     </properties>
 
-    <repositories>
-        <repository>
-            <id>jitpack.io</id>
-            <url>https://jitpack.io</url>
-        </repository>
-    </repositories>
-
     <profiles>
         <profile>
             <id>main</id>


### PR DESCRIPTION
remove dependency on jitpack.io (we'll need to wait for it to sync)