### PR TITLE
bump: chicory-sdk 0.1.1

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>org.extism.sdk</groupId>
             <artifactId>chicory-sdk</artifactId>
-            <version>0.1.0</version>
+            <version>${mcpx4j.version}</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <mcpx4j.version>0.1.1</mcpx4j.version>
         <junit-jupiter.version>5.11.0</junit-jupiter.version>
         <jakarta.json-api.version>2.1.3</jakarta.json-api.version>
         <mockserver-client-java.version>5.14.0</mockserver-client-java.version>
@@ -80,7 +81,7 @@
         <profile>
             <id>main</id>
             <activation>
-                <activeByDefault>false</activeByDefault>
+                <activeByDefault>true</activeByDefault>
                 <property><name>!release</name></property>
             </activation>
             <modules>


### PR DESCRIPTION
update to the last version bump, with a fix for WASI