### PR TITLE
feat: add oauth support, bump chicory 0.1.2

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -24,7 +24,12 @@
             <version>${jackson-databind.version}</version>
             <optional>true</optional>
         </dependency>
-
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <version>${jackson-databind.version}</version>
+            <optional>true</optional>
+        </dependency>
         <dependency>
             <groupId>org.eclipse.parsson</groupId>
             <artifactId>parsson</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>org.extism.sdk</groupId>
             <artifactId>chicory-sdk</artifactId>
-            <version>${mcpx4j.version}</version>
+            <version>${chicory-sdk.version}</version>
         </dependency>
 
         <dependency>

--- a/core/src/main/java/com/dylibso/mcpx4j/core/HttpClient.java
+++ b/core/src/main/java/com/dylibso/mcpx4j/core/HttpClient.java
@@ -3,7 +3,9 @@ package com.dylibso.mcpx4j.core;
 import org.extism.sdk.chicory.HttpClientAdapter;
 
 import java.net.URI;
+import java.util.List;
 import java.util.Map;
+import java.util.StringTokenizer;
 
 public class HttpClient {
     private final String baseUrl;
@@ -30,6 +32,29 @@ public class HttpClient {
             throw new HttpClientException("Failed to fetch installations: " + httpAdapter.statusCode());
         }
         return jsonDecoder.servletInstalls(bytes);
+    }
+
+    // GET /api/profiles/{user}/{profile}/installations/{installation}/oauth
+    public ServletOAuth oauth(String profileId, ServletInstall servletInstall) {
+        var uri = URI.create(baseUrl + "/api/profiles/" + profileId + "/installations/" + servletInstall.name() + "/oauth");
+        byte[] bytes = httpAdapter.request("GET", uri, Map.of("Cookie", "sessionId=" + apiKey), new byte[0]);
+        if (httpAdapter.statusCode() != 200) {
+            throw new HttpClientException("Failed to fetch OAuth info: " + httpAdapter.statusCode());
+        }
+        var headers = httpAdapter.headers();
+        int maxAge = 0;
+        long time = System.currentTimeMillis();
+        for (String cc : headers.get("Cache-Control")) {
+            var tok = new StringTokenizer(cc, ",=");
+            if (tok.nextToken().equals("max-age")) {
+                maxAge = Integer.parseInt(tok.nextToken());
+            }
+        }
+
+        ServletOAuthInfo oauthInfo = jsonDecoder.oauth(bytes);
+        ServletOAuth servletOAuth = new ServletOAuth(oauthInfo, time + maxAge, maxAge);
+
+        return servletOAuth;
     }
 
     // GET /c/{contentAddress}

--- a/core/src/main/java/com/dylibso/mcpx4j/core/HttpClient.java
+++ b/core/src/main/java/com/dylibso/mcpx4j/core/HttpClient.java
@@ -44,10 +44,13 @@ public class HttpClient {
         var headers = httpAdapter.headers();
         int maxAge = 0;
         long time = System.currentTimeMillis();
-        for (String cc : headers.get("Cache-Control")) {
-            var tok = new StringTokenizer(cc, ",=");
-            if (tok.nextToken().equals("max-age")) {
-                maxAge = Integer.parseInt(tok.nextToken());
+        List<String> cacheControl = headers.get("Cache-Control");
+        if (cacheControl != null) {
+            for (String cc : cacheControl) {
+                var tok = new StringTokenizer(cc, ",=");
+                if (tok.nextToken().equals("max-age")) {
+                    maxAge = Integer.parseInt(tok.nextToken());
+                }
             }
         }
 

--- a/core/src/main/java/com/dylibso/mcpx4j/core/JacksonDecoder.java
+++ b/core/src/main/java/com/dylibso/mcpx4j/core/JacksonDecoder.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -19,7 +21,8 @@ public class JacksonDecoder implements JsonDecoder {
     public JacksonDecoder() {
         this.mapper = new ObjectMapper()
                 .setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.ANY)
-                .configure(com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+                .configure(com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                .registerModule(new JavaTimeModule());
     }
 
     @Override

--- a/core/src/main/java/com/dylibso/mcpx4j/core/JacksonDecoder.java
+++ b/core/src/main/java/com/dylibso/mcpx4j/core/JacksonDecoder.java
@@ -56,6 +56,16 @@ public class JacksonDecoder implements JsonDecoder {
         }
     }
 
+    @Override
+    public ServletOAuthInfo oauth(byte[] bytes) {
+        try {
+            var installs = mapper.readTree(bytes).get("oauth_info");
+            return mapper.treeToValue(installs, ServletOAuthInfo.class);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
     private static class McpxToolReader {
         private static McpxToolDescriptor readToolDescriptor(JsonNode toolObject) {
             var name = toolObject.get("name").asText();

--- a/core/src/main/java/com/dylibso/mcpx4j/core/JakartaJsonDecoder.java
+++ b/core/src/main/java/com/dylibso/mcpx4j/core/JakartaJsonDecoder.java
@@ -39,6 +39,14 @@ public class JakartaJsonDecoder implements JsonDecoder {
         return jsonObject.getJsonObject("params").getJsonObject("arguments").getString("q");
     }
 
+    @Override
+    public ServletOAuthInfo oauth(byte[] bytes) {
+        var jsonObject = Json.createReader(new ByteArrayInputStream(bytes)).readObject().getJsonObject("oauth_info");
+        var configName = jsonObject.getString("config_name");
+        var accessToken = jsonObject.getString("access_token");
+        return new ServletOAuthInfo(configName, accessToken);
+    }
+
     private static class McpxToolReader {
         private static McpxToolDescriptor readToolDescriptor(JsonObject toolObject) {
             var name = toolObject.getString("name");

--- a/core/src/main/java/com/dylibso/mcpx4j/core/JsonDecoder.java
+++ b/core/src/main/java/com/dylibso/mcpx4j/core/JsonDecoder.java
@@ -9,4 +9,6 @@ public interface JsonDecoder {
     List<McpxToolDescriptor> toolDescriptors(byte[] bytes);
 
     String parseSearchRequest(byte[] bytes);
+
+    ServletOAuthInfo oauth(byte[] bytes);
 }

--- a/core/src/main/java/com/dylibso/mcpx4j/core/Mcpx.java
+++ b/core/src/main/java/com/dylibso/mcpx4j/core/Mcpx.java
@@ -120,7 +120,9 @@ public class Mcpx {
     public void refreshInstallations() {
         Map<String, ServletInstall> installations = client.installations(profileSlug);
         servletInstalls.putAll(installations);
-        refreshOauth();
+        if (config.oAuthAutoRefresh) {
+            refreshOauth();
+        }
     }
 
     public void refreshOauth() {
@@ -138,7 +140,7 @@ public class Mcpx {
     }
 
     OAuthAwareConfigProvider refreshOauth(ServletInstall install, long now) {
-        if (!install.settings().permissions().oauthClient()) {
+        if (!install.settings().permissions().oAuthClient()) {
             return new OAuthAwareConfigProvider(install.settings.config());
         }
         String name = install.name();

--- a/core/src/main/java/com/dylibso/mcpx4j/core/McpxPluginTool.java
+++ b/core/src/main/java/com/dylibso/mcpx4j/core/McpxPluginTool.java
@@ -19,6 +19,10 @@ public class McpxPluginTool implements McpxTool {
         this.inputschema = descriptor.inputSchema();
     }
 
+    public void updateOAuth(ServletOAuth oAuth) {
+        // FIXME plugin.setVar(...) ?
+    }
+
     @Override
     public String name() {
         return name;

--- a/core/src/main/java/com/dylibso/mcpx4j/core/McpxServletFactory.java
+++ b/core/src/main/java/com/dylibso/mcpx4j/core/McpxServletFactory.java
@@ -54,7 +54,7 @@ public class McpxServletFactory {
     public static McpxServletFactory create(byte[] bytes, String name, ServletInstall install, McpxServletOptions config, JsonDecoder jsonDecoder) {
         var wasm = ManifestWasm.fromBytes(bytes).build();
         Manifest.Options opts = new Manifest.Options()
-                .withConfig(install.settings().config())
+                .withConfigProvider(install.settings().config())
                 .withAllowedHosts(install.settings().permissions().network().domains())
                 .withHttpConfig(config.chicoryHttpConfig)
                 .withWasi(WasiOptions.builder()

--- a/core/src/main/java/com/dylibso/mcpx4j/core/McpxServletFactory.java
+++ b/core/src/main/java/com/dylibso/mcpx4j/core/McpxServletFactory.java
@@ -1,6 +1,7 @@
 package com.dylibso.mcpx4j.core;
 
 import com.dylibso.chicory.wasi.WasiOptions;
+import org.extism.sdk.chicory.ConfigProvider;
 import org.extism.sdk.chicory.ExtismHostFunction;
 import org.extism.sdk.chicory.ExtismValType;
 import org.extism.sdk.chicory.Manifest;
@@ -51,10 +52,10 @@ public class McpxServletFactory {
         return new McpxServlet(this.install.name(), this.install, tools);
     }
 
-    public static McpxServletFactory create(byte[] bytes, String name, ServletInstall install, McpxServletOptions config, JsonDecoder jsonDecoder) {
+    public static McpxServletFactory create(byte[] bytes, String name, ServletInstall install, ConfigProvider configProvider, McpxServletOptions config, JsonDecoder jsonDecoder) {
         var wasm = ManifestWasm.fromBytes(bytes).build();
         Manifest.Options opts = new Manifest.Options()
-                .withConfigProvider(install.settings().config())
+                .withConfigProvider(configProvider)
                 .withAllowedHosts(install.settings().permissions().network().domains())
                 .withHttpConfig(config.chicoryHttpConfig)
                 .withWasi(WasiOptions.builder()

--- a/core/src/main/java/com/dylibso/mcpx4j/core/McpxServletOptions.java
+++ b/core/src/main/java/com/dylibso/mcpx4j/core/McpxServletOptions.java
@@ -6,11 +6,13 @@ import org.extism.sdk.chicory.HttpConfig;
 
 public class McpxServletOptions {
     final boolean aot;
+    public boolean oAuthAutoRefresh;
     final HttpConfig chicoryHttpConfig;
     final Logger logger;
 
-    McpxServletOptions(boolean aot, HttpConfig chicoryHttpConfig, Logger logger) {
+    McpxServletOptions(boolean aot, boolean oAuthAutoRefresh, HttpConfig chicoryHttpConfig, Logger logger) {
         this.aot = aot;
+        this.oAuthAutoRefresh = oAuthAutoRefresh;
         this.chicoryHttpConfig = chicoryHttpConfig;
         this.logger = logger;
     }
@@ -21,6 +23,7 @@ public class McpxServletOptions {
 
     public static class Builder {
         boolean aot;
+        boolean oAuthAutoRefresh;
         HttpConfig chicoryHttpConfig;
         Logger chicoryLogger;
 
@@ -28,6 +31,10 @@ public class McpxServletOptions {
 
         public Builder withAot() {
             this.aot = true;
+            return this;
+        }
+        public Builder withOAuthAutoRefresh() {
+            this.oAuthAutoRefresh = true;
             return this;
         }
 
@@ -44,6 +51,7 @@ public class McpxServletOptions {
         public McpxServletOptions build() {
             return new McpxServletOptions(
                     aot,
+                    oAuthAutoRefresh,
                     chicoryHttpConfig == null? HttpConfig.defaultConfig() : chicoryHttpConfig,
                     chicoryLogger == null? new SystemLogger() : chicoryLogger);
         }

--- a/core/src/main/java/com/dylibso/mcpx4j/core/OAuthAwareConfigProvider.java
+++ b/core/src/main/java/com/dylibso/mcpx4j/core/OAuthAwareConfigProvider.java
@@ -1,0 +1,39 @@
+package com.dylibso.mcpx4j.core;
+
+import org.extism.sdk.chicory.ConfigProvider;
+
+import java.util.Map;
+import java.util.Objects;
+
+public class OAuthAwareConfigProvider implements ConfigProvider {
+    volatile ServletOAuthInfo info;
+    private final Map<String, String> map;
+
+    public OAuthAwareConfigProvider(Map<String, String> config) {
+        this.map = config;
+    }
+
+    public void updateOAuth(ServletOAuthInfo info) {
+        this.info = info;
+    }
+
+    @Override
+    public String get(String key) {
+        if (info.configName().equals(key)) {
+            return info.accessToken();
+        }
+        return map.get(key);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof OAuthAwareConfigProvider)) return false;
+        OAuthAwareConfigProvider that = (OAuthAwareConfigProvider) o;
+        return Objects.equals(info, that.info) && Objects.equals(map, that.map);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(info, map);
+    }
+}

--- a/core/src/main/java/com/dylibso/mcpx4j/core/OAuthAwareConfigProvider.java
+++ b/core/src/main/java/com/dylibso/mcpx4j/core/OAuthAwareConfigProvider.java
@@ -6,19 +6,28 @@ import java.util.Map;
 import java.util.Objects;
 
 public class OAuthAwareConfigProvider implements ConfigProvider {
-    volatile ServletOAuthInfo info;
-    private final Map<String, String> map;
+    volatile ServletOAuth oAuth;
+    private Map<String, String> map;
+
+    public OAuthAwareConfigProvider(){
+        this.map = Map.of();
+    }
 
     public OAuthAwareConfigProvider(Map<String, String> config) {
         this.map = config;
     }
 
-    public void updateOAuth(ServletOAuthInfo info) {
-        this.info = info;
+    public ServletOAuth oAuth() {
+        return oAuth;
+    }
+
+    public void updateOAuth(ServletOAuth oAuth) {
+        this.oAuth = oAuth;
     }
 
     @Override
     public String get(String key) {
+        ServletOAuthInfo info = oAuth.info();
         if (info.configName().equals(key)) {
             return info.accessToken();
         }
@@ -29,11 +38,12 @@ public class OAuthAwareConfigProvider implements ConfigProvider {
     public boolean equals(Object o) {
         if (!(o instanceof OAuthAwareConfigProvider)) return false;
         OAuthAwareConfigProvider that = (OAuthAwareConfigProvider) o;
-        return Objects.equals(info, that.info) && Objects.equals(map, that.map);
+        return Objects.equals(oAuth, that.oAuth) && Objects.equals(map, that.map);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(info, map);
+        return Objects.hash(oAuth, map);
     }
+
 }

--- a/core/src/main/java/com/dylibso/mcpx4j/core/ServletDescriptor.java
+++ b/core/src/main/java/com/dylibso/mcpx4j/core/ServletDescriptor.java
@@ -5,16 +5,16 @@ import java.util.Objects;
 
 public class ServletDescriptor {
     String slug;
-    OffsetDateTime createdAt;
-    OffsetDateTime modifiedAt;
+    OffsetDateTime created_at;
+    OffsetDateTime modified_at;
     Meta meta;
 
     ServletDescriptor() {}
 
     public ServletDescriptor(String slug, OffsetDateTime createdAt, OffsetDateTime modifiedAt, Meta meta) {
         this.slug = slug;
-        this.createdAt = createdAt;
-        this.modifiedAt = modifiedAt;
+        this.created_at = createdAt;
+        this.modified_at = modifiedAt;
         this.meta = meta;
     }
 
@@ -23,11 +23,11 @@ public class ServletDescriptor {
     }
 
     public OffsetDateTime createdAt() {
-        return createdAt;
+        return created_at;
     }
 
     public OffsetDateTime modifiedAt() {
-        return modifiedAt;
+        return modified_at;
     }
 
     public Meta meta() {
@@ -38,20 +38,20 @@ public class ServletDescriptor {
     public boolean equals(Object o) {
         if (!(o instanceof ServletDescriptor)) return false;
         ServletDescriptor that = (ServletDescriptor) o;
-        return Objects.equals(slug, that.slug) && Objects.equals(createdAt, that.createdAt) && Objects.equals(modifiedAt, that.modifiedAt);
+        return Objects.equals(slug, that.slug) && Objects.equals(created_at, that.created_at) && Objects.equals(modified_at, that.modified_at);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(slug, createdAt, modifiedAt);
+        return Objects.hash(slug, created_at, modified_at);
     }
 
     @Override
     public String toString() {
         return "ServletDescriptor{" +
                 "slug='" + slug + '\'' +
-                ", createdAt=" + createdAt +
-                ", modifiedAt=" + modifiedAt +
+                ", createdAt=" + created_at +
+                ", modifiedAt=" + modified_at +
                 '}';
     }
 

--- a/core/src/main/java/com/dylibso/mcpx4j/core/ServletInstallReader.java
+++ b/core/src/main/java/com/dylibso/mcpx4j/core/ServletInstallReader.java
@@ -37,7 +37,7 @@ public class ServletInstallReader {
 
     static ServletSettings readSettings(JsonObject settings) {
         ServletSettings servletSettings = new ServletSettings(
-                asMap(settings.getJsonObject("config")),
+                new OAuthAwareConfigProvider(asMap(settings.getJsonObject("config"))),
                 readPermissions(settings.getJsonObject("permissions")));
         return servletSettings;
     }

--- a/core/src/main/java/com/dylibso/mcpx4j/core/ServletInstallReader.java
+++ b/core/src/main/java/com/dylibso/mcpx4j/core/ServletInstallReader.java
@@ -37,7 +37,7 @@ public class ServletInstallReader {
 
     static ServletSettings readSettings(JsonObject settings) {
         ServletSettings servletSettings = new ServletSettings(
-                new OAuthAwareConfigProvider(asMap(settings.getJsonObject("config"))),
+                asMap(settings.getJsonObject("config")),
                 readPermissions(settings.getJsonObject("permissions")));
         return servletSettings;
     }

--- a/core/src/main/java/com/dylibso/mcpx4j/core/ServletInstallReader.java
+++ b/core/src/main/java/com/dylibso/mcpx4j/core/ServletInstallReader.java
@@ -46,12 +46,14 @@ public class ServletInstallReader {
         if (permissions == null) {
             return new ServletSettings.Permissions(
                     readPermissionsNetwork(null),
-                    new ServletSettings.Permissions.FileSystem(Map.of())
+                    new ServletSettings.Permissions.FileSystem(Map.of()),
+                    false
             );
         }
         return new ServletSettings.Permissions(
                 readPermissionsNetwork(permissions.getJsonObject("network")),
-                readPermissionsFilesystem(permissions.getJsonObject("filesystem"))
+                readPermissionsFilesystem(permissions.getJsonObject("filesystem")),
+                permissions.getBoolean("oauth_client")
         );
     }
 

--- a/core/src/main/java/com/dylibso/mcpx4j/core/ServletOAuth.java
+++ b/core/src/main/java/com/dylibso/mcpx4j/core/ServletOAuth.java
@@ -1,0 +1,29 @@
+package com.dylibso.mcpx4j.core;
+
+public class ServletOAuth {
+    ServletOAuthInfo info;
+    long maxTimestamp;
+    int maxAge;
+
+    ServletOAuth() {}
+
+    ServletOAuth(ServletOAuthInfo info, long maxTimestamp, int maxAge) {
+        this.info = info;
+        this.maxTimestamp = maxTimestamp;
+        this.maxAge = maxAge;
+    }
+
+    public ServletOAuthInfo info() {
+        return info;
+    }
+
+    public long maxTimestamp() {
+        return maxTimestamp;
+    }
+
+    public int maxAge() {
+        return maxAge;
+    }
+
+
+}

--- a/core/src/main/java/com/dylibso/mcpx4j/core/ServletOAuthInfo.java
+++ b/core/src/main/java/com/dylibso/mcpx4j/core/ServletOAuthInfo.java
@@ -1,7 +1,33 @@
 package com.dylibso.mcpx4j.core;
 
+import java.util.Objects;
+
 public class ServletOAuthInfo {
     String configName;
     String accessToken;
     ServletOAuthInfo(){}
+
+    public ServletOAuthInfo(String configName, String accessToken) {
+        this.configName = configName;
+        this.accessToken = accessToken;
+    }
+
+    public String configName() {
+        return configName;
+    }
+    public String accessToken() {
+        return accessToken;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof ServletOAuthInfo)) return false;
+        ServletOAuthInfo that = (ServletOAuthInfo) o;
+        return Objects.equals(configName, that.configName) && Objects.equals(accessToken, that.accessToken);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(configName, accessToken);
+    }
 }

--- a/core/src/main/java/com/dylibso/mcpx4j/core/ServletOAuthInfo.java
+++ b/core/src/main/java/com/dylibso/mcpx4j/core/ServletOAuthInfo.java
@@ -1,0 +1,7 @@
+package com.dylibso.mcpx4j.core;
+
+public class ServletOAuthInfo {
+    String configName;
+    String accessToken;
+    ServletOAuthInfo(){}
+}

--- a/core/src/main/java/com/dylibso/mcpx4j/core/ServletSettings.java
+++ b/core/src/main/java/com/dylibso/mcpx4j/core/ServletSettings.java
@@ -5,17 +5,17 @@ import java.util.Map;
 import java.util.Objects;
 
 public final class ServletSettings {
-    private OAuthAwareConfigProvider config;
+    private Map<String, String> config;
     private Permissions permissions;
 
     ServletSettings() {}
 
-    public ServletSettings(OAuthAwareConfigProvider configProvider, Permissions permissions) {
+    public ServletSettings(Map<String, String> config, Permissions permissions) {
         this.config = config;
         this.permissions = permissions;
     }
 
-    public OAuthAwareConfigProvider config() {
+    public Map<String, String> config() {
         return config;
     }
 

--- a/core/src/main/java/com/dylibso/mcpx4j/core/ServletSettings.java
+++ b/core/src/main/java/com/dylibso/mcpx4j/core/ServletSettings.java
@@ -47,13 +47,14 @@ public final class ServletSettings {
     public static final class Permissions {
         Network network;
         FileSystem filesystem;
-        boolean oauthClient;
+        boolean oauth_client;
 
         Permissions() {}
 
-        public Permissions(Network network, FileSystem filesystem) {
+        public Permissions(Network network, FileSystem filesystem, boolean oAuthClient) {
             this.network = network;
             this.filesystem = filesystem;
+            this.oauth_client = oAuthClient;
         }
 
         public Network network() {
@@ -64,8 +65,8 @@ public final class ServletSettings {
             return filesystem;
         }
 
-        public boolean oauthClient() {
-            return oauthClient;
+        public boolean oAuthClient() {
+            return oauth_client;
         }
 
         @Override
@@ -75,12 +76,12 @@ public final class ServletSettings {
             var that = (Permissions) obj;
             return Objects.equals(this.network, that.network) &&
                     Objects.equals(this.filesystem, that.filesystem) &&
-                    this.oauthClient == that.oauthClient;
+                    this.oauth_client == that.oauth_client;
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(network, filesystem, oauthClient);
+            return Objects.hash(network, filesystem, oauth_client);
         }
 
         @Override
@@ -88,7 +89,7 @@ public final class ServletSettings {
             return "Permissions[" +
                     "network=" + network + ", " +
                     "filesystem=" + filesystem +
-                    "oauthClient=" + oauthClient + ", " + ']';
+                    "oauthClient=" + oauth_client + ", " + ']';
         }
 
         public static final class Network {

--- a/core/src/main/java/com/dylibso/mcpx4j/core/ServletSettings.java
+++ b/core/src/main/java/com/dylibso/mcpx4j/core/ServletSettings.java
@@ -5,17 +5,17 @@ import java.util.Map;
 import java.util.Objects;
 
 public final class ServletSettings {
-    private Map<String, String> config;
+    private OAuthAwareConfigProvider config;
     private Permissions permissions;
 
     ServletSettings() {}
 
-    public ServletSettings(Map<String, String> config, Permissions permissions) {
+    public ServletSettings(OAuthAwareConfigProvider configProvider, Permissions permissions) {
         this.config = config;
         this.permissions = permissions;
     }
 
-    public Map<String, String> config() {
+    public OAuthAwareConfigProvider config() {
         return config;
     }
 
@@ -47,6 +47,7 @@ public final class ServletSettings {
     public static final class Permissions {
         Network network;
         FileSystem filesystem;
+        boolean oauthClient;
 
         Permissions() {}
 
@@ -63,25 +64,31 @@ public final class ServletSettings {
             return filesystem;
         }
 
+        public boolean oauthClient() {
+            return oauthClient;
+        }
+
         @Override
         public boolean equals(Object obj) {
             if (obj == this) return true;
             if (obj == null || obj.getClass() != this.getClass()) return false;
             var that = (Permissions) obj;
             return Objects.equals(this.network, that.network) &&
-                    Objects.equals(this.filesystem, that.filesystem);
+                    Objects.equals(this.filesystem, that.filesystem) &&
+                    this.oauthClient == that.oauthClient;
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(network, filesystem);
+            return Objects.hash(network, filesystem, oauthClient);
         }
 
         @Override
         public String toString() {
             return "Permissions[" +
                     "network=" + network + ", " +
-                    "filesystem=" + filesystem + ']';
+                    "filesystem=" + filesystem +
+                    "oauthClient=" + oauthClient + ", " + ']';
         }
 
         public static final class Network {

--- a/core/src/main/java/com/dylibso/mcpx4j/core/builtins/McpRunServlet.java
+++ b/core/src/main/java/com/dylibso/mcpx4j/core/builtins/McpRunServlet.java
@@ -3,7 +3,6 @@ package com.dylibso.mcpx4j.core.builtins;
 import com.dylibso.mcpx4j.core.HttpClient;
 import com.dylibso.mcpx4j.core.JsonDecoder;
 import com.dylibso.mcpx4j.core.McpxServlet;
-import com.dylibso.mcpx4j.core.OAuthAwareConfigProvider;
 import com.dylibso.mcpx4j.core.ServletDescriptor;
 import com.dylibso.mcpx4j.core.ServletInstall;
 import com.dylibso.mcpx4j.core.ServletSettings;
@@ -20,7 +19,7 @@ public class McpRunServlet extends McpxServlet {
                                 OffsetDateTime.now(),
                                 OffsetDateTime.now(),
                                 new ServletDescriptor.Meta("", "")),
-                        new ServletSettings(new OAuthAwareConfigProvider(Map.of()), null)),
+                        new ServletSettings(Map.of(), null)),
                 Map.of("search_servlets", new McpRunSearchTool(client, jsonDecoder)));
     }
 }

--- a/core/src/main/java/com/dylibso/mcpx4j/core/builtins/McpRunServlet.java
+++ b/core/src/main/java/com/dylibso/mcpx4j/core/builtins/McpRunServlet.java
@@ -3,6 +3,7 @@ package com.dylibso.mcpx4j.core.builtins;
 import com.dylibso.mcpx4j.core.HttpClient;
 import com.dylibso.mcpx4j.core.JsonDecoder;
 import com.dylibso.mcpx4j.core.McpxServlet;
+import com.dylibso.mcpx4j.core.OAuthAwareConfigProvider;
 import com.dylibso.mcpx4j.core.ServletDescriptor;
 import com.dylibso.mcpx4j.core.ServletInstall;
 import com.dylibso.mcpx4j.core.ServletSettings;
@@ -19,7 +20,7 @@ public class McpRunServlet extends McpxServlet {
                                 OffsetDateTime.now(),
                                 OffsetDateTime.now(),
                                 new ServletDescriptor.Meta("", "")),
-                        new ServletSettings(Map.of(), null)),
+                        new ServletSettings(new OAuthAwareConfigProvider(Map.of()), null)),
                 Map.of("search_servlets", new McpRunSearchTool(client, jsonDecoder)));
     }
 }

--- a/core/src/test/java/com/dylibso/mcpx4j/core/HttpClientIT.java
+++ b/core/src/test/java/com/dylibso/mcpx4j/core/HttpClientIT.java
@@ -45,7 +45,7 @@ class HttpClientIT {
             assertNotNull(cfg);
             ServletSettings settings = cfg.settings();
             assertEquals(new ServletSettings(
-                    new OAuthAwareConfigProvider(Map.of("username", "foo")),
+                    Map.of("username", "foo"),
                     new ServletSettings.Permissions(
                             new ServletSettings.Permissions.Network("*.example.com"),
                             new ServletSettings.Permissions.FileSystem(Map.of("/home/foo", "${HOME}"))

--- a/core/src/test/java/com/dylibso/mcpx4j/core/HttpClientIT.java
+++ b/core/src/test/java/com/dylibso/mcpx4j/core/HttpClientIT.java
@@ -45,7 +45,7 @@ class HttpClientIT {
             assertNotNull(cfg);
             ServletSettings settings = cfg.settings();
             assertEquals(new ServletSettings(
-                    Map.of("username", "foo"),
+                    new OAuthAwareConfigProvider(Map.of("username", "foo")),
                     new ServletSettings.Permissions(
                             new ServletSettings.Permissions.Network("*.example.com"),
                             new ServletSettings.Permissions.FileSystem(Map.of("/home/foo", "${HOME}"))

--- a/core/src/test/java/com/dylibso/mcpx4j/core/HttpClientIT.java
+++ b/core/src/test/java/com/dylibso/mcpx4j/core/HttpClientIT.java
@@ -48,7 +48,8 @@ class HttpClientIT {
                     Map.of("username", "foo"),
                     new ServletSettings.Permissions(
                             new ServletSettings.Permissions.Network("*.example.com"),
-                            new ServletSettings.Permissions.FileSystem(Map.of("/home/foo", "${HOME}"))
+                            new ServletSettings.Permissions.FileSystem(Map.of("/home/foo", "${HOME}")),
+                            true
                     )), settings);
         } finally {
             server.stop(0);

--- a/core/src/test/java/com/dylibso/mcpx4j/core/McpxIT.java
+++ b/core/src/test/java/com/dylibso/mcpx4j/core/McpxIT.java
@@ -36,7 +36,11 @@ class McpxIT {
             var mcpx = Mcpx.forApiKey("my-key")
                     .withBaseUrl(baseUrl)
                     .withProfile(profileId)
-                    .withJsonDecoder(jsonDecoder).build();
+                    .withJsonDecoder(jsonDecoder)
+                    .withServletOptions(
+                            McpxServletOptions.builder()
+                                    .withOAuthAutoRefresh().build())
+                    .build();
             mcpx.refreshInstallations();
             McpxServletFactory servletFactory = mcpx.get("fetch");
 

--- a/core/src/test/java/com/dylibso/mcpx4j/core/MockServer.java
+++ b/core/src/test/java/com/dylibso/mcpx4j/core/MockServer.java
@@ -6,6 +6,7 @@ import com.sun.net.httpserver.HttpServer;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
 
 public class MockServer {
     static HttpServer installations(InetSocketAddress address) throws IOException {
@@ -21,6 +22,27 @@ public class MockServer {
 
         server.createContext("/api/profiles/~/default/installations", httpHandler);
         server.createContext("/api/profiles/foo/bar/installations", httpHandler);
+        server.createContext("/api/profiles/~/default/installations/fetch/oauth", t -> {
+            // {
+            //   "oauth_info": {
+            //      "config_name": "OAUTH_TOKEN",
+            //      "access_token": "ABCDFGHILMN123456789",
+            //   }
+            // }
+
+            byte[] resp = ("{\n" +
+                    "  \"oauth_info\": {\n" +
+                    "     \"config_name\": \"OAUTH_TOKEN\",\n" +
+                    "     \"access_token\": \"ABCDFGHILMN123456789\"\n" +
+                    "  }\n" +
+                    "}").getBytes(StandardCharsets.UTF_8);
+
+            t.sendResponseHeaders(200, resp.length);
+            OutputStream responseBody = t.getResponseBody();
+
+            responseBody.write(resp);
+            responseBody.close();
+        });
 
         return server;
     }

--- a/core/src/test/resources/installations.json
+++ b/core/src/test/resources/installations.json
@@ -4,6 +4,7 @@
       "name": "fetch",
       "settings": {
         "permissions": {
+          "oauth_client": true,
           "network": {
             "domains": [
               "*.example.com"

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <chicory-sdk.version>0.1.2</chicory-sdk.version>
         <mcpx4j.version>999-SNAPSHOT</mcpx4j.version>
         <junit-jupiter.version>5.11.0</junit-jupiter.version>
         <jakarta.json-api.version>2.1.3</jakarta.json-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <mcpx4j.version>0.1.1</mcpx4j.version>
+        <mcpx4j.version>999-SNAPSHOT</mcpx4j.version>
         <junit-jupiter.version>5.11.0</junit-jupiter.version>
         <jakarta.json-api.version>2.1.3</jakarta.json-api.version>
         <mockserver-client-java.version>5.14.0</mockserver-client-java.version>


### PR DESCRIPTION
We allow to mutate the oauth config keys using a mutable config provider. This is an implementation detail, servlets should act as if they were restarted each and re-read the config keys each time.

We introduce a `mcpx.refreshOAuth()` method that can be scheduled concurrently with `mcpx.refreshInstallations()` (notice that however, `refreshInstallations()` currently also refreshes oAuth info). 

`refreshOAuth()` comes in two overloads:
- a no-args `refreshOAuth()` that refreshes all the OAuth tokens in all the servlets that need one
- a specific `refreshOAuth(ServletInstall install, String name, long now)` that updates one specific servlet

