### PR TITLE
examples: android should lazy load servlets

### DIFF
--- a/core/src/main/java/com/dylibso/mcpx4j/core/Mcpx.java
+++ b/core/src/main/java/com/dylibso/mcpx4j/core/Mcpx.java
@@ -124,7 +124,7 @@ public class Mcpx {
         Map<String, ServletInstall> installations = client.installations(profileSlug);
         servletInstalls.putAll(installations);
         if (config.oAuthAutoRefresh) {
-//            refreshOauth();
+            refreshOauth();
         }
     }
 
@@ -143,22 +143,22 @@ public class Mcpx {
     }
 
     OAuthAwareConfigProvider refreshOauth(ServletInstall install, long now) {
+        if (!install.settings().permissions().oAuthClient()) {
             return new OAuthAwareConfigProvider(install.settings.config());
-//        if (!install.settings().permissions().oAuthClient()) {
-//        }
-//        String name = install.name();
-//        OAuthAwareConfigProvider servletOAuth = oauthTokens.get(name);
-//        if (servletOAuth == null) {
-//            var oAuth = client.oauth(profileSlug, install);
-//            servletOAuth =
-//                    new OAuthAwareConfigProvider(install.settings().config());
-//            servletOAuth.updateOAuth(oAuth);
-//            oauthTokens.put(name, servletOAuth);
-//        } else if (servletOAuth.oAuth().maxTimestamp() > now) {
-//            var oAuth = client.oauth(profileSlug, install);
-//            servletOAuth.updateOAuth(oAuth);
-//        }
-//        return servletOAuth;
+        }
+        String name = install.name();
+        OAuthAwareConfigProvider servletOAuth = oauthTokens.get(name);
+        if (servletOAuth == null) {
+            var oAuth = client.oauth(profileSlug, install);
+            servletOAuth =
+                    new OAuthAwareConfigProvider(install.settings().config());
+            servletOAuth.updateOAuth(oAuth);
+            oauthTokens.put(name, servletOAuth);
+        } else if (servletOAuth.oAuth().maxTimestamp() > now) {
+            var oAuth = client.oauth(profileSlug, install);
+            servletOAuth.updateOAuth(oAuth);
+        }
+        return servletOAuth;
     }
 
     public McpxServletFactory get(String name) {

--- a/core/src/main/java/com/dylibso/mcpx4j/core/Mcpx.java
+++ b/core/src/main/java/com/dylibso/mcpx4j/core/Mcpx.java
@@ -117,14 +117,14 @@ public class Mcpx {
         this.plugins = new ConcurrentHashMap<>();
         this.servletInstalls = new ConcurrentHashMap<>();
         this.oauthTokens = new ConcurrentHashMap<>();
-        this.builtIns = List.of(new McpRunServlet(client, jsonDecoder));
+        this.builtIns = List.of(/*new McpRunServlet(client, jsonDecoder)*/);
     }
 
     public void refreshInstallations() {
         Map<String, ServletInstall> installations = client.installations(profileSlug);
         servletInstalls.putAll(installations);
         if (config.oAuthAutoRefresh) {
-            refreshOauth();
+//            refreshOauth();
         }
     }
 
@@ -143,22 +143,22 @@ public class Mcpx {
     }
 
     OAuthAwareConfigProvider refreshOauth(ServletInstall install, long now) {
-        if (!install.settings().permissions().oAuthClient()) {
             return new OAuthAwareConfigProvider(install.settings.config());
-        }
-        String name = install.name();
-        OAuthAwareConfigProvider servletOAuth = oauthTokens.get(name);
-        if (servletOAuth == null) {
-            var oAuth = client.oauth(profileSlug, install);
-            servletOAuth =
-                    new OAuthAwareConfigProvider(install.settings().config());
-            servletOAuth.updateOAuth(oAuth);
-            oauthTokens.put(name, servletOAuth);
-        } else if (servletOAuth.oAuth().maxTimestamp() > now) {
-            var oAuth = client.oauth(profileSlug, install);
-            servletOAuth.updateOAuth(oAuth);
-        }
-        return servletOAuth;
+//        if (!install.settings().permissions().oAuthClient()) {
+//        }
+//        String name = install.name();
+//        OAuthAwareConfigProvider servletOAuth = oauthTokens.get(name);
+//        if (servletOAuth == null) {
+//            var oAuth = client.oauth(profileSlug, install);
+//            servletOAuth =
+//                    new OAuthAwareConfigProvider(install.settings().config());
+//            servletOAuth.updateOAuth(oAuth);
+//            oauthTokens.put(name, servletOAuth);
+//        } else if (servletOAuth.oAuth().maxTimestamp() > now) {
+//            var oAuth = client.oauth(profileSlug, install);
+//            servletOAuth.updateOAuth(oAuth);
+//        }
+//        return servletOAuth;
     }
 
     public McpxServletFactory get(String name) {

--- a/core/src/main/java/com/dylibso/mcpx4j/core/McpxServletFactory.java
+++ b/core/src/main/java/com/dylibso/mcpx4j/core/McpxServletFactory.java
@@ -2,5 +2,8 @@ package com.dylibso.mcpx4j.core;
 
 public interface McpxServletFactory {
     String name();
+
+    String schema();
+
     McpxServlet create();
 }

--- a/core/src/main/java/com/dylibso/mcpx4j/core/McpxWasmServletFactory.java
+++ b/core/src/main/java/com/dylibso/mcpx4j/core/McpxWasmServletFactory.java
@@ -54,8 +54,7 @@ public class McpxWasmServletFactory implements McpxServletFactory {
                 .withHostFunctions(DEPRECATED_CONFIG_GET.get())
                 .build();
 
-        var bytes = plugin.call("describe", new byte[0]);
-        var descriptors = jsonDecoder.toolDescriptors(bytes);
+        var descriptors = jsonDecoder.toolDescriptors(schema().getBytes(StandardCharsets.UTF_8));
         Map<String, McpxTool> tools = descriptors.stream()
                 .map(descriptor -> new McpxPluginTool(plugin, descriptor))
                 .collect(Collectors.toMap(McpxPluginTool::name, tool -> tool));

--- a/core/src/main/java/com/dylibso/mcpx4j/core/McpxWasmServletFactory.java
+++ b/core/src/main/java/com/dylibso/mcpx4j/core/McpxWasmServletFactory.java
@@ -34,6 +34,11 @@ public class McpxWasmServletFactory implements McpxServletFactory {
         return install;
     }
 
+    @Override
+    public String schema() {
+        return install.servlet.meta.schema;
+    }
+
     public Manifest manifest() {
         return manifest;
     }

--- a/core/src/main/java/com/dylibso/mcpx4j/core/McpxWasmServletFactory.java
+++ b/core/src/main/java/com/dylibso/mcpx4j/core/McpxWasmServletFactory.java
@@ -8,6 +8,7 @@ import org.extism.sdk.chicory.Manifest;
 import org.extism.sdk.chicory.ManifestWasm;
 import org.extism.sdk.chicory.Plugin;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;

--- a/core/src/main/java/com/dylibso/mcpx4j/core/OAuthAwareConfigProvider.java
+++ b/core/src/main/java/com/dylibso/mcpx4j/core/OAuthAwareConfigProvider.java
@@ -27,9 +27,11 @@ public class OAuthAwareConfigProvider implements ConfigProvider {
 
     @Override
     public String get(String key) {
-        ServletOAuthInfo info = oAuth.info();
-        if (info.configName().equals(key)) {
-            return info.accessToken();
+        if (oAuth != null) {
+            ServletOAuthInfo info = oAuth.info();
+            if (info.configName().equals(key)) {
+                return info.accessToken();
+            }
         }
         return map.get(key);
     }

--- a/core/src/main/java/com/dylibso/mcpx4j/core/ServletDescriptor.java
+++ b/core/src/main/java/com/dylibso/mcpx4j/core/ServletDescriptor.java
@@ -66,8 +66,8 @@ public class ServletDescriptor {
             this.lastContentAddress = lastContentAddress;
         }
 
-        void setSchema(Object schema) {
-            this.schema = schema.toString();
+        void setSchema(String schema) {
+            this.schema = schema;
         }
 
         public String schema() {

--- a/core/src/main/java/com/dylibso/mcpx4j/core/builtins/McpRunSearchTool.java
+++ b/core/src/main/java/com/dylibso/mcpx4j/core/builtins/McpRunSearchTool.java
@@ -15,6 +15,7 @@ public class McpRunSearchTool extends McpxBuiltInTool {
                     "If no tools are found, suggest the user create one at mcp.run.\n" +
                     "\n" +
                     "Search proactively - don't wait for users to ask about tools. Anytime you're helping with a task that external code could enhance, do a search.\n";
+    //language=json
     private static final String INPUT_SCHEMA =
             "{\n" +
                     "      \"type\": \"object\",\n" +

--- a/core/src/main/java/com/dylibso/mcpx4j/core/builtins/McpxBuiltInServlet.java
+++ b/core/src/main/java/com/dylibso/mcpx4j/core/builtins/McpxBuiltInServlet.java
@@ -3,6 +3,8 @@ package com.dylibso.mcpx4j.core.builtins;
 import com.dylibso.mcpx4j.core.McpxServlet;
 import com.dylibso.mcpx4j.core.McpxServletFactory;
 
+import java.util.stream.Collectors;
+
 public interface McpxBuiltInServlet extends McpxServlet {
     default McpxServletFactory asFactory() {
         var self = this;
@@ -10,6 +12,13 @@ public interface McpxBuiltInServlet extends McpxServlet {
             @Override
             public String name() {
                 return self.name();
+            }
+
+            @Override
+            public String schema() {
+                return self.tools().entrySet().stream()
+                        .map(e -> '"' + e.getKey() + '"' + ':' + e.getValue())
+                        .collect(Collectors.joining(",", "{\"tools\":{", "}}"));
             }
 
             @Override

--- a/examples/android-gemini/app/build.gradle.kts
+++ b/examples/android-gemini/app/build.gradle.kts
@@ -55,6 +55,7 @@ dependencies {
     implementation(libs.generativeai)
     implementation(libs.mcpx4j)
     implementation(libs.jackson.databind)
+    implementation(libs.jackson.datatype.jsr310)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/examples/android-gemini/app/src/main/java/com/dylibso/mcpx4j/examples/gemini/BakingScreen.kt
+++ b/examples/android-gemini/app/src/main/java/com/dylibso/mcpx4j/examples/gemini/BakingScreen.kt
@@ -109,11 +109,17 @@ fun BakingScreen(
 
             Button(
                 onClick = {
-                    val bitmap = BitmapFactory.decodeResource(
-                        context.resources,
-                        images[selectedImage.intValue]
+                    val bitmaps = listOf(BitmapFactory.decodeResource(
+                            context.resources,
+                            images[0]
+                        ),
+                        BitmapFactory.decodeResource(
+                            context.resources,
+                            images[1]
+                        )
                     )
-                    bakingViewModel.sendPrompt(bitmap, prompt)
+
+                    bakingViewModel.sendPrompt(bitmaps, prompt)
                 },
                 enabled = prompt.isNotEmpty(),
                 modifier = Modifier

--- a/examples/android-gemini/app/src/main/java/com/dylibso/mcpx4j/examples/gemini/BakingViewModel.kt
+++ b/examples/android-gemini/app/src/main/java/com/dylibso/mcpx4j/examples/gemini/BakingViewModel.kt
@@ -31,7 +31,7 @@ class BakingViewModel : ViewModel() {
     }
 
     fun sendPrompt(
-        bitmap: Bitmap,
+        bitmaps: List<Bitmap>,
         prompt: String
     ) {
         _uiState.value = UiState.Loading
@@ -40,7 +40,8 @@ class BakingViewModel : ViewModel() {
             try {
                 val response = generativeModel.generateContent(
                     content {
-                        image(bitmap)
+                        image(bitmaps[0])
+                        image(bitmaps[1])
                         text(prompt)
                     }
                 )

--- a/examples/android-gemini/app/src/main/java/com/dylibso/mcpx4j/examples/gemini/ChatSession.kt
+++ b/examples/android-gemini/app/src/main/java/com/dylibso/mcpx4j/examples/gemini/ChatSession.kt
@@ -1,5 +1,6 @@
 package com.dylibso.mcpx4j.examples.gemini
 
+import android.content.Context
 import com.google.ai.client.generativeai.GenerativeModel
 import com.google.ai.client.generativeai.type.Content
 import com.google.ai.client.generativeai.type.FunctionResponsePart
@@ -7,7 +8,7 @@ import com.google.ai.client.generativeai.type.GenerateContentResponse
 import com.google.ai.client.generativeai.type.Tool
 import com.google.ai.client.generativeai.type.content
 
-class ChatSession(private val functionRepository: FunctionRepository) {
+class ChatSession(private val context: Context, private val functionRepository: FunctionRepository) {
     private val generativeModel = GenerativeModel(
         // Use Gemini 2.0
         modelName = "gemini-2.0-flash-exp",

--- a/examples/android-gemini/app/src/main/java/com/dylibso/mcpx4j/examples/gemini/ChatSession.kt
+++ b/examples/android-gemini/app/src/main/java/com/dylibso/mcpx4j/examples/gemini/ChatSession.kt
@@ -1,6 +1,5 @@
 package com.dylibso.mcpx4j.examples.gemini
 
-import android.content.Context
 import com.google.ai.client.generativeai.GenerativeModel
 import com.google.ai.client.generativeai.type.Content
 import com.google.ai.client.generativeai.type.FunctionResponsePart
@@ -8,7 +7,7 @@ import com.google.ai.client.generativeai.type.GenerateContentResponse
 import com.google.ai.client.generativeai.type.Tool
 import com.google.ai.client.generativeai.type.content
 
-class ChatSession(private val context: Context, private val functionRepository: FunctionRepository) {
+class ChatSession(private val functionRepository: FunctionRepository) {
     private val generativeModel = GenerativeModel(
         // Use Gemini 2.0
         modelName = "gemini-2.0-flash-exp",

--- a/examples/android-gemini/app/src/main/java/com/dylibso/mcpx4j/examples/gemini/FunctionRepository.kt
+++ b/examples/android-gemini/app/src/main/java/com/dylibso/mcpx4j/examples/gemini/FunctionRepository.kt
@@ -1,44 +1,45 @@
 package com.dylibso.mcpx4j.examples.gemini
 
 import android.util.Log
+import androidx.collection.LruCache
 import com.dylibso.mcpx4j.core.Mcpx
 import com.dylibso.mcpx4j.core.McpxServlet
-import com.dylibso.mcpx4j.core.McpxTool
 import com.google.ai.client.generativeai.type.FunctionDeclaration
 import org.json.JSONObject
-import java.util.WeakHashMap
 
 data class FunctionRepository(
     val mcpx: Mcpx,
     val functionDeclarations: Map<String, FunctionDeclaration>,
     val mcpxTools: Map<String, String>) {
 
-    val servlets = mutableMapOf<String, McpxServlet>()
+    val servlets = object : LruCache<String, McpxServlet>(20) {
+        override fun create(servletName: String): McpxServlet {
+            val servletFactory = mcpx[servletName]
+            return servletFactory.create()
+        }
+    }
 
-    fun call(name: String, args: Map<String, String?>): JSONObject {
-        val toolName = mcpxTools[name]
-            ?: return JSONObject(mapOf("result" to "$name is not a valid function"))
+    fun call(toolName: String, args: Map<String, String?>): JSONObject {
+        val servletName = mcpxTools[toolName]
+            ?: return JSONObject(mapOf("result" to "$toolName is not a valid function"))
 
         val jargs = JSONObject(args)
         val jsargs = JSONObject(mapOf(
             "method" to "tools/call",
             "params" to mapOf(
-                "name" to name,
+                "name" to toolName,
                 "arguments" to jargs
             )))
 
-        Log.i("mcpx4j-tool", "invoking $name with args = $jargs")
+        Log.i("mcpx4j-tool", "looking up $toolName")
         // Invoke the mcp.run tool with the given arguments
-        val servletName = mcpxTools[toolName]
-        val servlet = servlets.getOrPut(servletName!!) {
-            val servletFactory = mcpx[servletName]
-            servletFactory.create()
-        }
+        val servlet = servlets[servletName]!!
 
+        Log.i("mcpx4j-tool", "invoking $toolName with args = $jargs")
         val tool = servlet.tools()[toolName]!!
 
         val res = tool.call(jsargs.toString())
-        Log.i("mcpx4j-tool", "$name returned: $res")
+        Log.i("mcpx4j-tool", "$toolName returned: $res")
 
         // Ensure we always return a map
         return JSONObject(mapOf("result" to res))

--- a/examples/android-gemini/app/src/main/java/com/dylibso/mcpx4j/examples/gemini/FunctionRepository.kt
+++ b/examples/android-gemini/app/src/main/java/com/dylibso/mcpx4j/examples/gemini/FunctionRepository.kt
@@ -10,7 +10,8 @@ import org.json.JSONObject
 data class FunctionRepository(
     val mcpx: Mcpx,
     val functionDeclarations: Map<String, FunctionDeclaration>,
-    val mcpxTools: Map<String, String>) {
+    val mcpxTools: Map<String, String>
+) {
 
     val servlets = object : LruCache<String, McpxServlet>(20) {
         override fun create(servletName: String): McpxServlet {
@@ -24,12 +25,15 @@ data class FunctionRepository(
             ?: return JSONObject(mapOf("result" to "$toolName is not a valid function"))
 
         val jargs = JSONObject(args)
-        val jsargs = JSONObject(mapOf(
-            "method" to "tools/call",
-            "params" to mapOf(
-                "name" to toolName,
-                "arguments" to jargs
-            )))
+        val jsargs = JSONObject(
+            mapOf(
+                "method" to "tools/call",
+                "params" to mapOf(
+                    "name" to toolName,
+                    "arguments" to jargs
+                )
+            )
+        )
 
         Log.i("mcpx4j-tool", "looking up $toolName")
         // Invoke the mcp.run tool with the given arguments

--- a/examples/android-gemini/app/src/main/java/com/dylibso/mcpx4j/examples/gemini/FunctionRepository.kt
+++ b/examples/android-gemini/app/src/main/java/com/dylibso/mcpx4j/examples/gemini/FunctionRepository.kt
@@ -1,16 +1,22 @@
 package com.dylibso.mcpx4j.examples.gemini
 
 import android.util.Log
+import com.dylibso.mcpx4j.core.Mcpx
+import com.dylibso.mcpx4j.core.McpxServlet
 import com.dylibso.mcpx4j.core.McpxTool
 import com.google.ai.client.generativeai.type.FunctionDeclaration
 import org.json.JSONObject
+import java.util.WeakHashMap
 
 data class FunctionRepository(
+    val mcpx: Mcpx,
     val functionDeclarations: Map<String, FunctionDeclaration>,
-    val mcpxTools: Map<String, McpxTool>) {
+    val mcpxTools: Map<String, String>) {
+
+    val servlets = mutableMapOf<String, McpxServlet>()
 
     fun call(name: String, args: Map<String, String?>): JSONObject {
-        val tool = mcpxTools[name]
+        val toolName = mcpxTools[name]
             ?: return JSONObject(mapOf("result" to "$name is not a valid function"))
 
         val jargs = JSONObject(args)
@@ -23,6 +29,14 @@ data class FunctionRepository(
 
         Log.i("mcpx4j-tool", "invoking $name with args = $jargs")
         // Invoke the mcp.run tool with the given arguments
+        val servletName = mcpxTools[toolName]
+        val servlet = servlets.getOrPut(servletName!!) {
+            val servletFactory = mcpx[servletName]
+            servletFactory.create()
+        }
+
+        val tool = servlet.tools()[toolName]!!
+
         val res = tool.call(jsargs.toString())
         Log.i("mcpx4j-tool", "$name returned: $res")
 

--- a/examples/android-gemini/app/src/main/java/com/dylibso/mcpx4j/examples/gemini/FunctionRepository.kt
+++ b/examples/android-gemini/app/src/main/java/com/dylibso/mcpx4j/examples/gemini/FunctionRepository.kt
@@ -13,7 +13,7 @@ data class FunctionRepository(
     val mcpxTools: Map<String, String>
 ) {
 
-    val servlets = object : LruCache<String, McpxServlet>(20) {
+    val servlets = object : LruCache<String, McpxServlet>(5) {
         override fun create(servletName: String): McpxServlet {
             val servletFactory = mcpx[servletName]
             return servletFactory.create()

--- a/examples/android-gemini/app/src/main/java/com/dylibso/mcpx4j/examples/gemini/ParsedSchema.kt
+++ b/examples/android-gemini/app/src/main/java/com/dylibso/mcpx4j/examples/gemini/ParsedSchema.kt
@@ -8,6 +8,10 @@ data class ParsedSchema(val parameters: List<Schema<*>>, val requiredParameters:
         fun parse(schema: String): ParsedSchema {
             val parsedJsonSchema = JSONObject(schema)
 
+            return parseObject(parsedJsonSchema)
+        }
+
+        fun parseObject(parsedJsonSchema: JSONObject): ParsedSchema {
             // Handle scalar types at the top level
             if (parsedJsonSchema.has("type") && !parsedJsonSchema.has("properties")) {
                 val type = parsedJsonSchema.getString("type")
@@ -37,7 +41,10 @@ data class ParsedSchema(val parameters: List<Schema<*>>, val requiredParameters:
 
             for (key in properties.keys()) {
                 val property = properties.getJSONObject(key)
-                val type = property.getString("type")
+                var type = "object"
+                if (property.has("type")) {
+                    type = property.getString("type")
+                }
                 val description = property.optString("description", type)
 
                 val schema = createSchemaForType(type, key, description, property)

--- a/examples/android-gemini/app/src/main/java/com/dylibso/mcpx4j/examples/gemini/ToolFetcher.kt
+++ b/examples/android-gemini/app/src/main/java/com/dylibso/mcpx4j/examples/gemini/ToolFetcher.kt
@@ -3,6 +3,7 @@ package com.dylibso.mcpx4j.examples.gemini
 import com.dylibso.mcpx4j.core.*
 import com.google.ai.client.generativeai.type.*
 import org.extism.sdk.chicory.*
+import org.json.JSONObject
 
 object ToolFetcher {
     fun fetchFunctions(): FunctionRepository {
@@ -14,30 +15,49 @@ object ToolFetcher {
                         // Setup an HTTP client compatible with Android
                         // on the Chicory runtime
                         .withChicoryHttpConfig(HttpConfig.builder()
-                            .withJsonCodec(JacksonJsonCodec())
-                            .withClientAdapter(HttpUrlConnectionClientAdapter()).build())
+                            .withJsonCodec({ JacksonJsonCodec() })
+                            .withClientAdapter({ HttpUrlConnectionClientAdapter() }).build())
                         // Configure an alternative, Android-specific logger
                         .withChicoryLogger(AndroidLogger("mcpx4j-runtime"))
                         .build())
                 // Configure also the MCPX4J HTTP client to use
                 // the Android-compatible implementation
                 .withHttpClientAdapter(HttpUrlConnectionClientAdapter())
+                .withProfile("telegram")
                 .build()
 
         // Refresh once the list of installations.
         // This can be also scheduled for periodic refresh.
-        mcpx.refreshInstallations("default")
-        val servlets = mcpx.servlets()
+        mcpx.refreshInstallations()
 
         // Extract the metadata of each `McpxTool` into a `FunctionDeclaration`
         val functionDeclarations =
-            servlets.flatMap {
-                it.tools().map { it.value.name() to toFunctionDeclaration(it.value) } }.toMap()
+            mcpx.servletFactories().toList()
+                .flatMap  { toFunctionDeclarationList(it.schema()) }
+                .toList()
         // Create a map name -> McpxTool for quicker lookup
         val mcpxTools =
-            servlets.flatMap {
+            mcpx.servletFactories().flatMap {
                 it.tools().map { it.value.name() to it.value } }.toMap()
         return FunctionRepository(functionDeclarations, mcpxTools)
+    }
+
+    private fun toFunctionDeclarationList(toolSchemas: String): List<FunctionDeclaration> {
+        val tools = JSONObject(toolSchemas).getJSONObject("tools")
+        val declarations = mutableListOf<FunctionDeclaration>()
+        for (name in tools.keys()) {
+
+            val tool = tools.getJSONObject(name)
+            val parsedSchema = ParsedSchema.parseObject(tool.getJSONObject("inputSchema"))
+            val f = defineFunction(
+                name = tool.getString("name"),
+                description = tool.getString("description"),
+                parameters = parsedSchema.parameters,
+                requiredParameters = parsedSchema.requiredParameters
+            )
+            declarations.add(f)
+        }
+        return declarations;
     }
 
     private fun toFunctionDeclaration(tool: McpxTool): FunctionDeclaration {

--- a/examples/android-gemini/app/src/main/java/com/dylibso/mcpx4j/examples/gemini/ToolFetcher.kt
+++ b/examples/android-gemini/app/src/main/java/com/dylibso/mcpx4j/examples/gemini/ToolFetcher.kt
@@ -32,8 +32,9 @@ object ToolFetcher {
         mcpx.refreshInstallations()
 
         // Extract the metadata of each `McpxTool` into a `FunctionDeclaration`
+        val factories = mcpx.servletFactories().filter { !it.name().contains("telegram") }
         val functionDeclarations =
-            mcpx.servletFactories().toList()
+            factories.toList()
                 .associate { it.name() to toFunctionDeclarationList(it.schema()) }
         // Create a map name -> McpxServlet name for quicker lookup
         val mcpxTools =

--- a/examples/android-gemini/gradle/libs.versions.toml
+++ b/examples/android-gemini/gradle/libs.versions.toml
@@ -33,6 +33,7 @@ androidx-material3 = { group = "androidx.compose.material3", name = "material3" 
 generativeai = { group = "com.google.ai.client.generativeai", name = "generativeai", version.ref = "generativeai" }
 mcpx4j = { group = "com.dylibso.mcpx4j", name = "core", version.ref = "mcpx4j" }
 jackson-databind = { group = "com.fasterxml.jackson.core", name = "jackson-databind", version.ref = "jackson" }
+jackson-datatype-jsr310 = { group = "com.fasterxml.jackson.datatype", name = "jackson-datatype-jsr310", version.ref = "jackson" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/examples/android-gemini/local.properties.example
+++ b/examples/android-gemini/local.properties.example
@@ -6,3 +6,4 @@
 sdk.dir=<your-sdk-path>
 apiKey=<your-google-api-key>
 mcpRunKey=<your-mcp-run-session-id>
+profile=default

--- a/examples/spring-ai-mcpx4j-ollama/src/main/resources/application.properties
+++ b/examples/spring-ai-mcpx4j-ollama/src/main/resources/application.properties
@@ -5,4 +5,4 @@ spring.ai.ollama.chat.options.model=llama3.2
 
 mcpx.api-key=${MCP_RUN_API_KEY}
 mcpx.base-url=https://www.mcp.run
-mcpx.profile-id=default
+mcpx.profile-id=telegram


### PR DESCRIPTION
Use factories to lazy load tools, provide only the schemas, and add an LRU-cache to drop them when they are too many.