### PR TITLE
feat: use has_client for oauth, lazy load token

### DIFF
--- a/core/src/main/java/com/dylibso/mcpx4j/core/Mcpx.java
+++ b/core/src/main/java/com/dylibso/mcpx4j/core/Mcpx.java
@@ -143,7 +143,7 @@ public class Mcpx {
     }
 
     OAuthAwareConfigProvider refreshOauth(ServletInstall install, long now) {
-        if (!install.settings().permissions().oAuthClient()) {
+        if (!install.servlet().hasClient()) {
             return new OAuthAwareConfigProvider(install.settings.config());
         }
         String name = install.name();

--- a/core/src/main/java/com/dylibso/mcpx4j/core/Mcpx.java
+++ b/core/src/main/java/com/dylibso/mcpx4j/core/Mcpx.java
@@ -17,6 +17,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 public class Mcpx {
     public static class Builder {
@@ -159,9 +160,10 @@ public class Mcpx {
 
     public Collection<McpxServlet> servlets() {
         var servlets = new ArrayList<McpxServlet>(builtIns);
-        for (var name : servletInstalls.keySet()) {
-            servlets.add(this.get(name).create());
-        }
+        servlets.addAll(servletInstalls.keySet()
+                .parallelStream()
+                .map(k -> this.get(k).create())
+                .collect(Collectors.toList()));
         return servlets;
     }
 

--- a/core/src/main/java/com/dylibso/mcpx4j/core/McpxPluginTool.java
+++ b/core/src/main/java/com/dylibso/mcpx4j/core/McpxPluginTool.java
@@ -3,23 +3,21 @@ package com.dylibso.mcpx4j.core;
 import org.extism.sdk.chicory.Plugin;
 
 import java.nio.charset.StandardCharsets;
+import java.util.function.Supplier;
 
 public class McpxPluginTool implements McpxTool {
 
-    private final Plugin plugin;
+    private final Supplier<Plugin> pluginSupplier;
     private final String name;
     private final String description;
     private final String inputschema;
+    private volatile Plugin plugin;
 
-    McpxPluginTool(Plugin plugin, McpxToolDescriptor descriptor) {
-        this.plugin = plugin;
+    McpxPluginTool(Supplier<Plugin> pluginSupplier, McpxToolDescriptor descriptor) {
+        this.pluginSupplier = pluginSupplier;
         this.name = descriptor.name();
         this.description = descriptor.description();
         this.inputschema = descriptor.inputSchema();
-    }
-
-    public void updateOAuth(ServletOAuth oAuth) {
-        // FIXME plugin.setVar(...) ?
     }
 
     @Override
@@ -39,6 +37,9 @@ public class McpxPluginTool implements McpxTool {
 
     @Override
     public String call(String jsonInput) {
+        if (plugin == null) {
+            plugin = pl
+        }
         try {
             return new String(plugin.call(
                     "call",

--- a/core/src/main/java/com/dylibso/mcpx4j/core/McpxPluginTool.java
+++ b/core/src/main/java/com/dylibso/mcpx4j/core/McpxPluginTool.java
@@ -38,7 +38,7 @@ public class McpxPluginTool implements McpxTool {
     @Override
     public String call(String jsonInput) {
         if (plugin == null) {
-            plugin = pl
+            plugin = pluginSupplier.get();
         }
         try {
             return new String(plugin.call(

--- a/core/src/main/java/com/dylibso/mcpx4j/core/McpxPluginTool.java
+++ b/core/src/main/java/com/dylibso/mcpx4j/core/McpxPluginTool.java
@@ -1,6 +1,5 @@
 package com.dylibso.mcpx4j.core;
 
-import org.extism.sdk.chicory.ExtismException;
 import org.extism.sdk.chicory.Plugin;
 
 import java.nio.charset.StandardCharsets;
@@ -44,7 +43,7 @@ public class McpxPluginTool implements McpxTool {
             return new String(plugin.call(
                     "call",
                     jsonInput.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8);
-        } catch (ExtismException e) {
+        } catch (RuntimeException e) {
             return String.format("An error occurred while calling the function: %s", e.getMessage());
         }
     }

--- a/core/src/main/java/com/dylibso/mcpx4j/core/McpxWasmServletFactory.java
+++ b/core/src/main/java/com/dylibso/mcpx4j/core/McpxWasmServletFactory.java
@@ -49,14 +49,13 @@ public class McpxWasmServletFactory implements McpxServletFactory {
     }
 
     public McpxServlet create() {
-        var plugin = Plugin.ofManifest(manifest)
+        var pluginBuilder = Plugin.ofManifest(manifest)
                 .withLogger(config.logger)
-                .withHostFunctions(DEPRECATED_CONFIG_GET.get())
-                .build();
+                .withHostFunctions(DEPRECATED_CONFIG_GET.get());
 
         var descriptors = jsonDecoder.toolDescriptors(schema().getBytes(StandardCharsets.UTF_8));
         Map<String, McpxTool> tools = descriptors.stream()
-                .map(descriptor -> new McpxPluginTool(plugin, descriptor))
+                .map(descriptor -> new McpxPluginTool(pluginBuilder::build, descriptor))
                 .collect(Collectors.toMap(McpxPluginTool::name, tool -> tool));
         return new McpxWasmServlet(this.install.name(), this.install, tools);
     }

--- a/core/src/main/java/com/dylibso/mcpx4j/core/OAuthAwareConfigProvider.java
+++ b/core/src/main/java/com/dylibso/mcpx4j/core/OAuthAwareConfigProvider.java
@@ -4,29 +4,35 @@ import org.extism.sdk.chicory.ConfigProvider;
 
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Supplier;
 
 public class OAuthAwareConfigProvider implements ConfigProvider {
     volatile ServletOAuth oAuth;
     private Map<String, String> map;
+    private Supplier<ServletOAuth> oAuthSupplier;
 
     public OAuthAwareConfigProvider(){
         this.map = Map.of();
     }
 
-    public OAuthAwareConfigProvider(Map<String, String> config) {
+    public OAuthAwareConfigProvider(Map<String, String> config, Supplier<ServletOAuth> oAuthSupplier) {
         this.map = config;
+        this.oAuthSupplier = oAuthSupplier;
     }
 
     public ServletOAuth oAuth() {
         return oAuth;
     }
 
-    public void updateOAuth(ServletOAuth oAuth) {
-        this.oAuth = oAuth;
+    public void updateOAuth() {
+        this.oAuth = oAuthSupplier.get();
     }
 
     @Override
     public String get(String key) {
+        if (oAuth == null || oAuth.maxTimestamp() > System.currentTimeMillis()) {
+            updateOAuth();
+        }
         if (oAuth != null) {
             ServletOAuthInfo info = oAuth.info();
             if (info.configName().equals(key)) {

--- a/core/src/main/java/com/dylibso/mcpx4j/core/ServletDescriptor.java
+++ b/core/src/main/java/com/dylibso/mcpx4j/core/ServletDescriptor.java
@@ -8,14 +8,16 @@ public class ServletDescriptor {
     OffsetDateTime created_at;
     OffsetDateTime modified_at;
     Meta meta;
+    boolean has_client;
 
     ServletDescriptor() {}
 
-    public ServletDescriptor(String slug, OffsetDateTime createdAt, OffsetDateTime modifiedAt, Meta meta) {
+    public ServletDescriptor(String slug, OffsetDateTime createdAt, OffsetDateTime modifiedAt, Meta meta, boolean has_client) {
         this.slug = slug;
         this.created_at = createdAt;
         this.modified_at = modifiedAt;
         this.meta = meta;
+        this.has_client = has_client;
     }
 
     public String slug() {
@@ -32,6 +34,10 @@ public class ServletDescriptor {
 
     public Meta meta() {
         return meta;
+    }
+
+    public boolean hasClient() {
+        return has_client;
     }
 
     @Override
@@ -52,6 +58,7 @@ public class ServletDescriptor {
                 "slug='" + slug + '\'' +
                 ", createdAt=" + created_at +
                 ", modifiedAt=" + modified_at +
+                ", hasClient=" + has_client +
                 '}';
     }
 

--- a/core/src/main/java/com/dylibso/mcpx4j/core/ServletDescriptor.java
+++ b/core/src/main/java/com/dylibso/mcpx4j/core/ServletDescriptor.java
@@ -12,12 +12,12 @@ public class ServletDescriptor {
 
     ServletDescriptor() {}
 
-    public ServletDescriptor(String slug, OffsetDateTime createdAt, OffsetDateTime modifiedAt, Meta meta, boolean has_client) {
+    public ServletDescriptor(String slug, OffsetDateTime createdAt, OffsetDateTime modifiedAt, Meta meta, boolean hasClient) {
         this.slug = slug;
         this.created_at = createdAt;
         this.modified_at = modifiedAt;
         this.meta = meta;
-        this.has_client = has_client;
+        this.has_client = hasClient;
     }
 
     public String slug() {

--- a/core/src/main/java/com/dylibso/mcpx4j/core/ServletInstallReader.java
+++ b/core/src/main/java/com/dylibso/mcpx4j/core/ServletInstallReader.java
@@ -26,7 +26,9 @@ public class ServletInstallReader {
                 servlet.getString("slug"),
                 OffsetDateTime.parse(servlet.getString("created_at")),
                 OffsetDateTime.parse(servlet.getString("modified_at")),
-                readServletMeta(servlet.getJsonObject("meta")));
+                readServletMeta(servlet.getJsonObject("meta")),
+                servlet.getBoolean("has_client")
+        );
     }
 
     private static ServletDescriptor.Meta readServletMeta(JsonObject meta) {

--- a/core/src/main/java/com/dylibso/mcpx4j/core/ServletInstallReader.java
+++ b/core/src/main/java/com/dylibso/mcpx4j/core/ServletInstallReader.java
@@ -48,15 +48,11 @@ public class ServletInstallReader {
         if (permissions == null) {
             return new ServletSettings.Permissions(
                     readPermissionsNetwork(null),
-                    new ServletSettings.Permissions.FileSystem(Map.of()),
-                    false
-            );
+                    new ServletSettings.Permissions.FileSystem(Map.of()));
         }
         return new ServletSettings.Permissions(
                 readPermissionsNetwork(permissions.getJsonObject("network")),
-                readPermissionsFilesystem(permissions.getJsonObject("filesystem")),
-                permissions.getBoolean("oauth_client")
-        );
+                readPermissionsFilesystem(permissions.getJsonObject("filesystem")));
     }
 
     private static ServletSettings.Permissions.FileSystem readPermissionsFilesystem(JsonObject filesystem) {

--- a/core/src/main/java/com/dylibso/mcpx4j/core/ServletSettings.java
+++ b/core/src/main/java/com/dylibso/mcpx4j/core/ServletSettings.java
@@ -47,14 +47,12 @@ public final class ServletSettings {
     public static final class Permissions {
         Network network;
         FileSystem filesystem;
-        boolean oauth_client;
 
         Permissions() {}
 
-        public Permissions(Network network, FileSystem filesystem, boolean oAuthClient) {
+        public Permissions(Network network, FileSystem filesystem) {
             this.network = network;
             this.filesystem = filesystem;
-            this.oauth_client = oAuthClient;
         }
 
         public Network network() {
@@ -65,31 +63,25 @@ public final class ServletSettings {
             return filesystem;
         }
 
-        public boolean oAuthClient() {
-            return oauth_client;
-        }
-
         @Override
         public boolean equals(Object obj) {
             if (obj == this) return true;
             if (obj == null || obj.getClass() != this.getClass()) return false;
             var that = (Permissions) obj;
             return Objects.equals(this.network, that.network) &&
-                    Objects.equals(this.filesystem, that.filesystem) &&
-                    this.oauth_client == that.oauth_client;
+                    Objects.equals(this.filesystem, that.filesystem);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(network, filesystem, oauth_client);
+            return Objects.hash(network, filesystem);
         }
 
         @Override
         public String toString() {
             return "Permissions[" +
                     "network=" + network + ", " +
-                    "filesystem=" + filesystem +
-                    "oauthClient=" + oauth_client + ", " + ']';
+                    "filesystem=" + filesystem + ']';
         }
 
         public static final class Network {

--- a/core/src/test/java/com/dylibso/mcpx4j/core/HttpClientIT.java
+++ b/core/src/test/java/com/dylibso/mcpx4j/core/HttpClientIT.java
@@ -48,9 +48,7 @@ class HttpClientIT {
                     Map.of("username", "foo"),
                     new ServletSettings.Permissions(
                             new ServletSettings.Permissions.Network("*.example.com"),
-                            new ServletSettings.Permissions.FileSystem(Map.of("/home/foo", "${HOME}")),
-                            true
-                    )), settings);
+                            new ServletSettings.Permissions.FileSystem(Map.of("/home/foo", "${HOME}")))), settings);
         } finally {
             server.stop(0);
         }

--- a/core/src/test/resources/installations.json
+++ b/core/src/test/resources/installations.json
@@ -4,7 +4,6 @@
       "name": "fetch",
       "settings": {
         "permissions": {
-          "oauth_client": true,
           "network": {
             "domains": [
               "*.example.com"
@@ -89,7 +88,8 @@
           "lastContentAddress": "abcdefg"
         },
         "created_at": "2024-12-13T15:15:36.812622+01:00",
-        "modified_at": "2024-12-16T19:58:24.392251+01:00"
+        "modified_at": "2024-12-16T19:58:24.392251+01:00",
+        "has_client": true
       }
     }]
 }

--- a/examples/langchain4j-openai/pom.xml
+++ b/examples/langchain4j-openai/pom.xml
@@ -16,6 +16,7 @@
         <langchain4j.version>1.0.0-alpha1</langchain4j.version>
         <smallrye-config.version>3.10.1</smallrye-config.version>
         <slf4j-simple.version>2.0.13</slf4j-simple.version>
+        <jackson-datatype-jsr310.version>2.18.2</jackson-datatype-jsr310.version>
     </properties>
 
     <dependencies>
@@ -23,6 +24,12 @@
             <groupId>com.dylibso.mcpx4j</groupId>
             <artifactId>core</artifactId>
             <version>${mcpx4j.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <version>${jackson-datatype-jsr310.version}</version>
         </dependency>
 
         <dependency>

--- a/examples/spring-ai-mcpx4j-ollama/src/main/resources/application.properties
+++ b/examples/spring-ai-mcpx4j-ollama/src/main/resources/application.properties
@@ -5,4 +5,5 @@ spring.ai.ollama.chat.options.model=llama3.2
 
 mcpx.api-key=${MCP_RUN_API_KEY}
 mcpx.base-url=https://www.mcp.run
-mcpx.profile-id=telegram
+mcpx.profile-id=default
+


### PR DESCRIPTION
fixes #12

1. **OAuth Client Detection**: Changed from using `install.settings().permissions().oAuthClient()` to `install.servlet().hasClient()` for determining if a servlet requires OAuth authentication.

2. **Lazy Loading**: Implemented lazy loading of OAuth information, which improves performance by only loading OAuth tokens when needed.

3. **Configuration Provider**: Refactored the `OAuthAwareConfigProvider` class to use a supplier function for OAuth information, making the code more maintainable and flexible.

4. **Data Structure Updates**: 
   - Removed the `oauth_client` field from the `Permissions` class
   - Added a `has_client` field to the `ServletDescriptor` class
   - Updated JSON parsing to accommodate these changes

5. **Plugin Tool Improvements**: Modified `McpxPluginTool` to use a supplier for plugin creation, enabling lazy initialization.


This PR ensures that the mcpx4j library correctly identifies servlets that require OAuth authentication by using the proper field (`has_client`). This aligns with changes made in the main mcp.run repository.

The lazy loading improvements should also result in better performance, as OAuth tokens are only fetched when needed rather than preemptively for all servlets.

